### PR TITLE
Memtrace post-processing for bbv

### DIFF
--- a/src/frontend/frontend.c
+++ b/src/frontend/frontend.c
@@ -162,4 +162,19 @@ static void collect_op_stats(Op* op) {
     STAT_EVENT(op->proc_id, ST_NOT_MEM_OFFPATH + op->table_info->mem_type);
   }
 }
+
+#ifdef ENABLE_PT_MEMTRACE
+void frontend_extract_basic_block_vectors() {
+  switch(FRONTEND) {
+    case FE_PT:
+    case FE_MEMTRACE: {
+      ext_trace_extract_basic_block_vectors();
+      break;
+    }
+    default:
+      ASSERT(0, 0);
+      break;
+  }
+}
+#endif
 /*************************************************************/

--- a/src/frontend/frontend.h
+++ b/src/frontend/frontend.h
@@ -59,6 +59,10 @@ void frontend_recover(uns proc_id, uns64 inst_uid);
 /* Let the frontend know that this instruction is retired) */
 void frontend_retire(uns proc_id, uns64 inst_uid);
 
+#ifdef ENABLE_PT_MEMTRACE
+/* Trace post-processing to extract basic block vectors */
+void frontend_extract_basic_block_vectors(void);
+#endif
 /*************************************************************/
 
 #endif /*  __FRONTEND_H__*/

--- a/src/frontend/pt_memtrace/trace_fe.cc
+++ b/src/frontend/pt_memtrace/trace_fe.cc
@@ -7,7 +7,11 @@
 #include "pin/pin_lib/uop_generator.h"
 #include "pin/pin_lib/x86_decoder.h"
 #include "statistics.h"
+#include "sim.h"
 #include <iostream>
+#include <map>
+#include <fstream>
+#include <iomanip>
 
 #include "frontend/pt_memtrace/pt_fe.h"
 #include "frontend/frontend_intf.h"
@@ -266,4 +270,388 @@ void ext_trace_init() {
 
 void ext_trace_done() {
 
+}
+
+void output_fingerprint(std::map<uint64_t, uint64_t> fingerprint) {
+  // output the map for this segment
+  // make it a function?
+  std::ofstream myfile;
+  std::string bbv_output(TRACE_BBV_OUTPUT);
+  myfile.open(bbv_output, std::ofstream::out | std::ofstream::app);
+
+  if (!myfile.is_open()) {
+      printf("open file failed\n");
+  }
+
+  // std::cout << num_of_segments << "th fp dimensions: " << fingerprint.size() << std::endl;
+  // fine if comment starting here
+  std::map<uint64_t, uint64_t>::iterator freq;
+  uint64_t instrs_count = 0;
+
+  uint64_t nonzero_count = 0;
+  // static std::vector<uint64> csv_line(counts_as_built.blocks, 0);
+
+  for (freq = fingerprint.begin(); freq != fingerprint.end(); freq++) {
+      instrs_count += freq->second;
+      if(freq == fingerprint.begin()) {
+        myfile << "T";
+      }
+      myfile << ":" << freq->first << ":" << freq->second << " ";
+
+      // csv_line[freq->first] = freq->second;
+      nonzero_count++;
+
+      // if (freq->first + 1 == counts_as_built.blocks) {
+      //     witness_total = true;
+      // }
+  }
+
+  // ASSERT(proc_id, nonzero_count == fingerprint.size());
+  // ASSERT(proc_id, instrs_count == CHUNK_INSTR_COUNT);
+
+  myfile << std::endl;
+  myfile.close();
+}
+
+// ATTENTION: the string instruction expansion can inflate frenquency
+// those abstract inst type..
+void ext_trace_extract_basic_block_vectors() {
+  uint64_t op_taken_count[NUM_CF_TYPES] = {0};
+  const char *op_type_strings[] = {
+    "TRACE_INST_TAKEN_NOT_CF",
+    "TRACE_INST_TAKEN_CF_BR",
+    "TRACE_INST_TAKEN_CF_CBR",
+    "TRACE_INST_TAKEN_CF_CALL",
+    "TRACE_INST_TAKEN_CF_IBR",
+    "TRACE_INST_TAKEN_CF_ICALL",
+    "TRACE_INST_TAKEN_CF_ICO",
+    "TRACE_INST_TAKEN_CF_RET",
+    "TRACE_INST_TAKEN_CF_SYS",
+  };
+
+  std::vector<std::pair<std::string, uint64_t>> npc_op_count;
+
+  ASSERT(0, NUM_CORES == 1);
+  uns8 proc_id = 0;
+  ASSERT(proc_id, (FRONTEND == FE_PT) || (FRONTEND == FE_MEMTRACE));
+
+  typedef struct bb_counts {
+      uint64_t blocks;
+      uint64_t total_size;
+      uint64_t non_fetched;
+  } bb_counts;
+
+  typedef struct basic_block_info
+  {
+    // instruction list contained in this basic block
+    std::vector<ctype_pin_inst> ins_list;
+    // the basic block id
+    uint64_t bb_id;
+    uint64_t freq;
+    void clear() {
+      ins_list.clear();
+      bb_id = 0;
+      freq = 0;
+    }
+
+    basic_block_info() {
+      bb_id = 0;
+      ins_list = std::vector<ctype_pin_inst>();
+      freq = 0;
+    }
+
+    bool operator<(const basic_block_info& rhs) const
+    {
+      std::vector<ctype_pin_inst>::size_type size = ins_list.size() < rhs.ins_list.size()?
+                                                    ins_list.size() : rhs.ins_list.size();
+      for(unsigned i = 0 ; i < size; i++) {
+        if(ins_list[i].instruction_addr < rhs.ins_list[i].instruction_addr) {
+          return true;
+        }
+      }
+
+      if(ins_list.size() < rhs.ins_list.size()) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    bool operator!=(const basic_block_info& bb) const
+    {
+      if(ins_list.size() != bb.ins_list.size()) {
+        return true;
+      }
+
+      for(unsigned i = 0 ; i < this->ins_list.size(); i++) {
+        if(this->ins_list[i].instruction_addr != bb.ins_list[i].instruction_addr) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  } basic_block_info;
+
+  // global counters for the entire trace
+  bb_counts counts_dynamic{}, counts_as_built{};
+  uint64_t num_of_segments = 0;
+
+  // segment instruction counter, reset every segment
+  uint64_t cur_counter = 0;
+
+  // unordered map to hash basic block identifier to the basic block info
+  // the identifier: the first pc of the basic block
+  // this map is used throughout the post-processing
+  std::unordered_map<uint64_t, basic_block_info> bb_map;
+
+  std::unordered_map<uint64_t, std::vector<basic_block_info>> bb_identity_map;
+
+  // map to hash the basic block to the frequency counter
+  // essentially the fingerprint for a segment
+  // this map is cleared every SEGMENT_SIZE instruction
+  // mode 1: the key is the basic block id, used for the whole trace
+  // mode 2: the key is the first addr of the basic block, used for trace chunks
+  std::map<uint64_t, uint64_t> fingerprint;
+
+  // maintain the current basic block
+  basic_block_info cur_bb{};
+
+  // the first trace entry was read during frontend initialization
+  // assume the first read succeeded
+  ctype_pin_inst* inst = &next_onpath_pi[proc_id];
+  int success = true;
+
+  printf("read from initialization: %p\n", (void *)(inst->instruction_addr));
+
+  // continue till trace end
+  while(success) {
+    if(inst->actually_taken){
+      ASSERT(proc_id, inst->instruction_next_addr != inst->instruction_addr + inst->size);
+      ASSERT(proc_id, inst->cf_type);
+      op_taken_count[inst->cf_type]++;
+    }
+    if(inst->instruction_next_addr != inst->instruction_addr + inst->size) {
+      if(!inst->cf_type && !inst->is_repeat) {
+        fprintf(stderr, "the cf is not cf or rep %p\n", (void *)inst->instruction_addr);
+      }
+      ASSERT(proc_id, inst->cf_type || inst->is_repeat);
+    }
+
+    // add to current basic block
+    // a sequence of rep of same pc is a bb executed multiple times
+    cur_bb.ins_list.push_back(*inst);
+
+    // read the next instruction from the trace, which overwrites inst
+    if(FRONTEND == FE_PT)
+      success = pt_trace_read(proc_id, inst);
+    else if(FRONTEND == FE_MEMTRACE)
+      success = memtrace_trace_read(proc_id, inst);
+
+    if(cur_bb.ins_list.back().is_repeat && !inst->is_repeat) {
+      ASSERT(proc_id, cur_bb.ins_list.back().instruction_addr != inst->instruction_addr);
+    }
+
+    // decide if it's the end of current basic block
+    // - a cf
+    // - (current is not a rep but) the next is rep (the first half might be redundant)
+    // - a rep
+    // - the last trace entry
+    // note that at this point inst has the next instruction
+    // note that the next inst is available if success
+    // if so, find the frequency counter and increment
+
+    if(cur_bb.ins_list.back().cf_type ||
+        !success ||
+        (!cur_bb.ins_list.back().is_repeat && inst->is_repeat) ||
+        cur_bb.ins_list.back().is_repeat) {
+      std::unordered_map<uint64_t, basic_block_info>::iterator map_lookup =
+                                bb_map.find(cur_bb.ins_list.front().instruction_addr);
+
+      std::ofstream cinstf;
+      cinstf.open("cinst.log", std::ofstream::out | std::ofstream::app);
+      for (uint i = 0; i < cur_bb.ins_list.size(); i++) {
+        cinstf << std::hex
+               << std::setfill('0') << std::setw(sizeof(void *) * 2) << cur_bb.ins_list[i].instruction_addr
+               << std::dec << std::setfill(' ') << std::endl;
+      }
+      cinstf.close();
+      if(map_lookup != bb_map.end()) {
+        // not the first time bb
+        // the bb size might be cut if at boundary
+        cur_bb.bb_id = map_lookup->second.bb_id;
+
+        // sanity check: are they the same?
+        auto bb_key = cur_bb.ins_list.front().instruction_addr;
+        bool find = false;
+        for(unsigned i = 0; i < bb_identity_map[bb_key].size(); i++) {
+          if(cur_bb != bb_identity_map[bb_key][i]) {
+          } else {
+            find = true;
+            bb_identity_map[bb_key][i].freq++;
+            break;
+          }
+        }
+        if(!find) {
+          cur_bb.freq++;
+          bb_identity_map[bb_key].push_back(cur_bb);
+
+          for(uint i = 0; i < cur_bb.ins_list.size(); i++) {
+            fprintf(stderr, "[%lu]: ad: %p, op: %d\n", map_lookup->second.bb_id, (void *)cur_bb.ins_list[i].instruction_addr, cur_bb.ins_list[i].true_op_type);
+          }
+          fprintf(stderr, "DUP bb detected\n");
+        }
+      } else {
+        // a new bb, starting at 1
+        counts_as_built.blocks++;
+        cur_bb.bb_id = counts_as_built.blocks;
+        counts_as_built.total_size += cur_bb.ins_list.size();
+
+        // enter bb map
+        bb_map[cur_bb.ins_list.front().instruction_addr] = cur_bb;
+        // sanity check
+        cur_bb.freq++;
+        bb_identity_map[cur_bb.ins_list.front().instruction_addr].push_back(cur_bb);
+
+        // fprintf(stderr, "======================\n");
+        static int bb_built_count = 0;
+        for(uint i = 0; i < cur_bb.ins_list.size(); i++) {
+          fprintf(stderr, "[%d]: ad: %p, op: %d\n", bb_built_count, (void *)cur_bb.ins_list[i].instruction_addr, cur_bb.ins_list[i].true_op_type);
+        }
+        bb_built_count++;
+        fprintf(stderr, "new bb detected: %d\n", bb_built_count);
+        // fprintf(stderr, "======================\n");
+      }
+
+
+
+      counts_dynamic.blocks++;
+      counts_dynamic.total_size += cur_bb.ins_list.size();
+      cur_counter += cur_bb.ins_list.size();
+
+      // same as dynamorio client
+      uint64_t to_last_vector_count = 0;
+      uint64_t to_new_vector_count = 0;
+      if(cur_counter > CHUNK_INSTR_COUNT) {
+        // if at a boundary (excluding perfect aligned boundary)
+        to_new_vector_count = cur_counter - CHUNK_INSTR_COUNT;
+        to_last_vector_count = cur_bb.ins_list.size() - to_new_vector_count;
+      } else {
+        to_last_vector_count = cur_bb.ins_list.size();
+      }
+
+      ASSERT(proc_id, to_last_vector_count + to_new_vector_count == cur_bb.ins_list.size());
+      ASSERT(proc_id, (cur_counter > CHUNK_INSTR_COUNT) == (to_new_vector_count > 0));
+
+      if (SIM_MODE == TRACE_BBV_MODE) {
+        fingerprint[cur_bb.bb_id] += to_last_vector_count;
+      } else {
+        // TRACE_BBV_DISTRIBUTED_MODE
+        fingerprint[cur_bb.ins_list.front().instruction_addr] += to_last_vector_count;
+      }
+
+      // perfect alignment
+      // two fingerprint output condition
+      // - if reach segment limit
+      // - if it is the end of trace
+      // if two are both satisfied, will output twice
+      if(cur_counter >= CHUNK_INSTR_COUNT) {
+        num_of_segments++;
+
+        printf("to be appened segment num %ld\n", num_of_segments);
+        std::cout << counts_dynamic.total_size << std::endl;
+        for(uint i = 0; i < NUM_CF_TYPES; i++) {
+          std::cout << op_type_strings[i] << ":" << op_taken_count[i] << std::endl;
+        }
+
+        printf("indentity within this segment\n");
+        auto counter = 0;
+        for(auto i = bb_identity_map.begin(); i != bb_identity_map.end(); i++) {
+          if(i->second.size() > 1) {
+            counter++;
+            printf("%lu bbs with same first pc\n", i->second.size());
+            for(unsigned j = 0; j < i->second.size(); j++) {
+              printf("[%ld]: size %ld, freq %ld\n", i->second[j].bb_id, i->second[j].ins_list.size(), i->second[j].freq);
+              for(unsigned k = 0; k < i->second[j].ins_list.size(); k++) {
+                printf("%s: %u\n",
+                        hexstr64s(i->second[j].ins_list[k].instruction_addr),
+                        i->second[j].ins_list[k].true_op_type);
+              }
+            }
+          }
+        }
+        printf("%d / %ld (%ld)\n", counter, bb_identity_map.size(), fingerprint.size());
+        bb_identity_map.clear();
+        std::cout << "====================================\n";
+
+        cur_counter = 0;
+
+        output_fingerprint(fingerprint);
+        // clear for the next segment
+        fingerprint.clear();
+
+        printf(
+        "========================================================\n"
+        "Number of blocks built : %ld\n"
+        "     Average size      : %5.2lf instructions\n"
+        "Number of blocks executed  : %ld\n"
+        "     Average weighted size : %5.2lf instructions\n"
+        "Number of total instructions : %ld\n"
+        "========================================================\n"
+        ,
+        counts_as_built.blocks,
+        counts_as_built.total_size / (double)counts_as_built.blocks,
+        counts_dynamic.blocks,
+        counts_dynamic.total_size / (double)counts_dynamic.blocks,
+        counts_dynamic.total_size
+        );
+
+        // record the residue
+        if(to_new_vector_count > 0) {
+            if (SIM_MODE == TRACE_BBV_MODE) {
+              fingerprint.insert(std::make_pair(cur_bb.bb_id, to_new_vector_count));
+            } else {
+              // TRACE_BBV_DISTRIBUTED_MODE
+              uint64_t bb_addr = cur_bb.ins_list.front().instruction_addr;
+              fingerprint.insert(std::make_pair(bb_addr, to_new_vector_count));
+            }
+
+            cur_counter = to_new_vector_count;
+        }
+      }
+
+      // clear out current bb
+      cur_bb.clear();
+
+      if(!success) {
+        num_of_segments++;
+
+        printf("to be appened segment num %ld\n", num_of_segments);
+        std::cout << counts_dynamic.total_size << std::endl;
+        for(uint i = 0; i < NUM_CF_TYPES; i++) {
+          std::cout << op_type_strings[i] << ":" << op_taken_count[i] << std::endl;
+        }
+        std::cout << "====================================\n";
+
+        output_fingerprint(fingerprint);
+
+        // TODO: arrange the output for two output situations
+        printf(
+        "========================================================\n"
+        "Number of blocks built : %ld\n"
+        "     Average size      : %5.2lf instructions\n"
+        "Number of blocks executed  : %ld\n"
+        "     Average weighted size : %5.2lf instructions\n"
+        "Number of total instructions : %ld\n"
+        "========================================================\n"
+        ,
+        counts_as_built.blocks,
+        counts_as_built.total_size / (double)counts_as_built.blocks,
+        counts_dynamic.blocks,
+        counts_dynamic.total_size / (double)counts_dynamic.blocks,
+        counts_dynamic.total_size
+        );
+      }
+    }
+  }
 }

--- a/src/frontend/pt_memtrace/trace_fe.cc
+++ b/src/frontend/pt_memtrace/trace_fe.cc
@@ -468,14 +468,14 @@ void ext_trace_extract_basic_block_vectors() {
       std::unordered_map<uint64_t, basic_block_info>::iterator map_lookup =
                                 bb_map.find(cur_bb.ins_list.front().instruction_addr);
 
-      std::ofstream cinstf;
-      cinstf.open("cinst.log", std::ofstream::out | std::ofstream::app);
-      for (uint i = 0; i < cur_bb.ins_list.size(); i++) {
-        cinstf << std::hex
-               << std::setfill('0') << std::setw(sizeof(void *) * 2) << cur_bb.ins_list[i].instruction_addr
-               << std::dec << std::setfill(' ') << std::endl;
-      }
-      cinstf.close();
+      // std::ofstream cinstf;
+      // cinstf.open("cinst.log", std::ofstream::out | std::ofstream::app);
+      // for (uint i = 0; i < cur_bb.ins_list.size(); i++) {
+      //   cinstf << std::hex
+      //          << std::setfill('0') << std::setw(sizeof(void *) * 2) << cur_bb.ins_list[i].instruction_addr
+      //          << std::dec << std::setfill(' ') << std::endl;
+      // }
+      // cinstf.close();
       if(map_lookup != bb_map.end()) {
         // not the first time bb
         // the bb size might be cut if at boundary

--- a/src/frontend/pt_memtrace/trace_fe.h
+++ b/src/frontend/pt_memtrace/trace_fe.h
@@ -61,7 +61,7 @@ void ext_trace_recover(uns proc_id, uns64 inst_uid);
 void ext_trace_retire(uns proc_id, uns64 inst_uid);
 void ext_trace_init();
 void ext_trace_done(void);
-
+void ext_trace_extract_basic_block_vectors();
 #ifdef __cplusplus
 }
 #endif

--- a/src/general.param.def
+++ b/src/general.param.def
@@ -104,3 +104,6 @@ DEF_PARAM( num_nops                     , NUM_NOPS                   , uns64  , 
 DEF_PARAM( nops_bb_start                , NOPS_BB_START              , uns64  , uns64    , 0x5000000,       )
 
 DEF_PARAM( ignore_bar_fetch             , IGNORE_BAR_FETCH           , Flag   , Flag     , FALSE    ,       ) 
+
+DEF_PARAM( trace_bbv_output             , TRACE_BBV_OUTPUT          , char*  , string    , NULL     ,       )
+DEF_PARAM( chunk_instr_count            , CHUNK_INSTR_COUNT         , uns64  , uns64     , 100000000,       )

--- a/src/main.c
+++ b/src/main.c
@@ -271,6 +271,12 @@ int main(int argc, char* argv[], char* envp[]) {
     case FULL_SIM_MODE:
       full_sim();
       break;
+#ifdef ENABLE_PT_MEMTRACE
+    case TRACE_BBV_MODE:
+    case TRACE_BBV_DISTRIBUTED_MODE:
+      extract_basic_block_vectors();
+      break;
+#endif
     default:
       FATAL_ERROR(0, "Unknown simulation mode.");
       break;

--- a/src/param_parser.c
+++ b/src/param_parser.c
@@ -78,7 +78,12 @@ the program.  This way, an exact duplicate run can be performed.
 
 const char* help_options[]    = {"-help", "-h", "--help",
                               "--h"}; /* cmd-line help options strings */
-const char* sim_mode_names[]  = {"uop", "full"};
+const char* sim_mode_names[]  = {"uop", "full"
+#ifdef ENABLE_PT_MEMTRACE
+, "trace_bbv"
+, "trace_bbv_distributed"
+#endif
+};
 const char* exit_cond_names[] = {"last_done", "first_done"};
 
 /**************************************************************************************/

--- a/src/sim.c
+++ b/src/sim.c
@@ -840,3 +840,9 @@ void full_sim() {
 
 
 /**************************************************************************************/
+#ifdef ENABLE_PT_MEMTRACE
+/* trace_bbv: This is the main loop for extracting basic block vectors from the trace.*/
+void extract_basic_block_vectors() {
+  frontend_extract_basic_block_vectors();
+}
+#endif

--- a/src/sim.h
+++ b/src/sim.h
@@ -32,7 +32,15 @@
 /**************************************************************************************/
 /* Types */
 
-enum sim_mode_enum { UOP_SIM_MODE, FULL_SIM_MODE, NUM_SIM_MODES };
+enum sim_mode_enum {
+  UOP_SIM_MODE,
+  FULL_SIM_MODE,
+#ifdef ENABLE_PT_MEMTRACE
+  TRACE_BBV_MODE,
+  TRACE_BBV_DISTRIBUTED_MODE,
+#endif
+  NUM_SIM_MODES
+};
 
 enum operating_mode_enum {
   SIMULATION_MODE,
@@ -59,6 +67,9 @@ void full_sim(void);
 void handle_SIGINT(int);
 void close_output_streams(void);
 
+#ifdef ENABLE_PT_MEMTRACE
+void extract_basic_block_vectors(void);
+#endif
 
 /**************************************************************************************/
 


### PR DESCRIPTION
A new mode is added to process the trace to extract the fingerprint.

To use this mode, the following parameter should be used:
1. `--frontend memtrace`
2. `--cbp_trace_r0=<path to trace>`
3. `--memtrace_modules_log=<path to modules.log>`
4. `--mode=trace_bbv`
5. `--chunk_instr_count=<segment/chunk size>`, the granularity of SimPoint
6. `--trace_bbv_output=<fingerprint output path and name>`

If only a region of the trace is of interest, use the following two parameters:
1. `--memtrace_roi_begin=<instr count>`
2. `--memtrace_roi_end=<instr count>`

, where,

1. the instruction count starts with 1
2. the end instruction count is inclusive
4. end instruction count of 0 means till the end of the trace

If the mode is used to generate the fingerprint in a distributed way, the resulting fingerprint should not use specific basic block IDs, as the IDs are not synchronized between runs. Use `--mode=trace_bbv_distributed` in this case.