### PR TITLE
Refactor Confidence to Update on Every FT

### DIFF
--- a/src/confidence/conf.cc
+++ b/src/confidence/conf.cc
@@ -141,24 +141,38 @@ void Conf::set_prev_op(Op* op) {
   conf_mech->conf_mech_stat->set_prev_op(op);
 }
 
-void Conf::update(Op* op, Flag last_in_ft) {
-  ASSERT(proc_id, CONFIDENCE_ENABLE);
-  Conf_Off_Path_Reason new_reason = REASON_CONF_NOT_IDENTIFIED;
-  if (!conf_off_path)
+void Conf::process_op(Op* op, Conf_Off_Path_Reason& new_reason, bool last_in_ft) {
+  op->conf_off_path = conf_off_path;
+  if (!conf_off_path) {
     perfect_conf_update(op, new_reason);
-  if (!PERFECT_CONFIDENCE && new_reason == REASON_CONF_NOT_IDENTIFIED &&
-      (get_off_path_reason() == REASON_NOT_IDENTIFIED ||
-       get_conf_off_path_reason() == REASON_CONF_NOT_IDENTIFIED)) {  // update until both real/confidence path go off
-    per_op_update(op, new_reason);
-    if (op->table_info->cf_type)
-      per_cf_op_update(op, new_reason);
-    if (last_in_ft)
-      per_ft_update(op, new_reason);
+    if (!PERFECT_CONFIDENCE && new_reason == REASON_CONF_NOT_IDENTIFIED) {
+      per_op_update(op, new_reason);
+      if (op->table_info->cf_type)
+        per_cf_op_update(op, new_reason);
+    }
   }
-  conf_off_path = (conf_off_path || (new_reason != REASON_CONF_NOT_IDENTIFIED));
+
+  conf_off_path |= (new_reason != REASON_CONF_NOT_IDENTIFIED);
   conf_mech->conf_mech_stat->update(op, new_reason, last_in_ft);
   STAT_EVENT(proc_id, CONF_OFF_IBTB_MISS_BP_TAKEN + new_reason);
   set_prev_op(op);
+}
+
+void Conf::update(FT pushed_ft) {
+  ASSERT(proc_id, CONFIDENCE_ENABLE);
+
+  std::vector<Op*> ops = pushed_ft.get_ops();
+  if (ops.empty())
+    return;
+
+  Conf_Off_Path_Reason new_reason = REASON_CONF_NOT_IDENTIFIED;
+
+  for (auto op = ops.begin(); op != ops.end() - 1; ++op) {
+    process_op(*op, new_reason, false);
+  }
+
+  process_op(ops.back(), new_reason, true);
+  per_ft_update(ops.back(), new_reason);
 }
 
 void Conf::perfect_conf_update(Op* op, Conf_Off_Path_Reason& new_reason) {
@@ -217,7 +231,6 @@ void Conf::per_ft_update(Op* op, Conf_Off_Path_Reason& new_reason) {
 }
 
 void Conf::per_cycle_update() {
-  ASSERT(proc_id, PERFECT_CONFIDENCE ? conf_off_path == decoupled_fe_is_off_path() : true);
   if (PERFECT_CONFIDENCE)
     return;
   if (get_off_path_reason() != REASON_NOT_IDENTIFIED && get_conf_off_path_reason() != REASON_CONF_NOT_IDENTIFIED)

--- a/src/confidence/conf.cc
+++ b/src/confidence/conf.cc
@@ -8,7 +8,9 @@
 
 #define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_CONF, ##args)
 
-void ConfMechStatBase::per_cycle_update() {
+void ConfMechStatBase::per_cycle_update(Conf_Off_Path_Reason reason) {
+  if (conf_off_path_reason == REASON_CONF_NOT_IDENTIFIED && reason != REASON_CONF_NOT_IDENTIFIED)
+    conf_off_path_reason = reason;
   if (off_path_reason) {
     if (conf_off_path_reason) {
       STAT_EVENT(proc_id, DFE_OFF_CONF_OFF_REALISTIC_CYCLES + perfect_off_path);
@@ -170,9 +172,8 @@ void Conf::update(FT pushed_ft) {
   for (auto op = ops.begin(); op != ops.end() - 1; ++op) {
     process_op(*op, new_reason, false);
   }
-
-  process_op(ops.back(), new_reason, true);
   per_ft_update(ops.back(), new_reason);
+  process_op(ops.back(), new_reason, true);
 }
 
 void Conf::perfect_conf_update(Op* op, Conf_Off_Path_Reason& new_reason) {
@@ -238,6 +239,6 @@ void Conf::per_cycle_update() {
   Conf_Off_Path_Reason new_reason = REASON_CONF_NOT_IDENTIFIED;
   conf_mech->per_cycle_update(new_reason);
   conf_off_path = new_reason != REASON_CONF_NOT_IDENTIFIED;
-  conf_mech->conf_mech_stat->per_cycle_update();
+  conf_mech->conf_mech_stat->per_cycle_update(new_reason);
   STAT_EVENT(proc_id, CONF_OFF_IBTB_MISS_BP_TAKEN + new_reason);
 }

--- a/src/confidence/conf.cc
+++ b/src/confidence/conf.cc
@@ -234,11 +234,10 @@ void Conf::per_ft_update(Op* op, Conf_Off_Path_Reason& new_reason) {
 void Conf::per_cycle_update() {
   if (PERFECT_CONFIDENCE)
     return;
-  if (get_off_path_reason() != REASON_NOT_IDENTIFIED && get_conf_off_path_reason() != REASON_CONF_NOT_IDENTIFIED)
-    return;
   Conf_Off_Path_Reason new_reason = REASON_CONF_NOT_IDENTIFIED;
-  conf_mech->per_cycle_update(new_reason);
-  conf_off_path = new_reason != REASON_CONF_NOT_IDENTIFIED;
+  if (!conf_off_path)
+    conf_mech->per_cycle_update(new_reason);
+  conf_off_path |= new_reason != REASON_CONF_NOT_IDENTIFIED;
   conf_mech->conf_mech_stat->per_cycle_update(new_reason);
   STAT_EVENT(proc_id, CONF_OFF_IBTB_MISS_BP_TAKEN + new_reason);
 }

--- a/src/confidence/conf.hpp
+++ b/src/confidence/conf.hpp
@@ -96,7 +96,7 @@ class Conf {
   uns get_conf() { return conf_off_path; }
   void recover(Op* op, std::deque<FT>& ftq);
   void set_prev_op(Op* op);
-  void update(Op* op, Flag last_in_ft);
+  void update(FT ft_pushed);
   void resolve_cf(Op* op) { conf_mech->resolve_cf(op); }
   Off_Path_Reason get_off_path_reason() { return conf_mech->conf_mech_stat->get_off_path_reason(); }
   Conf_Off_Path_Reason get_conf_off_path_reason() { return conf_mech->conf_mech_stat->get_conf_off_path_reason(); }
@@ -110,6 +110,7 @@ class Conf {
   void per_ft_update(Op* op, Conf_Off_Path_Reason& new_reason);
   void update_state_perfect_conf(Op* op) { conf_mech->update_state_perfect_conf(op); }
   void perfect_conf_update(Op* op, Conf_Off_Path_Reason& new_reason);
+  void process_op(Op* op, Conf_Off_Path_Reason& new_reason, bool last_in_ft);
 
   // confidence mech object
   ConfMechBase* conf_mech;

--- a/src/confidence/conf.hpp
+++ b/src/confidence/conf.hpp
@@ -45,7 +45,7 @@ class ConfMechStatBase {
         conf_off_path_reason(REASON_CONF_NOT_IDENTIFIED),
         perfect_off_path(false) {}
   virtual void update(Op* op, Conf_Off_Path_Reason reason, bool last_in_ft);
-  virtual void per_cycle_update();
+  virtual void per_cycle_update(Conf_Off_Path_Reason reason);
   virtual void recover(Op* op, std::deque<FT>& ftq);
   virtual void print_data();
   void set_prev_op(Op* op);

--- a/src/decoupled_frontend.cc
+++ b/src/decoupled_frontend.cc
@@ -344,9 +344,7 @@ void Decoupled_FE::update() {
     frontend_fetch_op(proc_id, op);
     op->op_num = dfe_op_count++;
     op->off_path = off_path;
-    if (CONFIDENCE_ENABLE)
-      op->conf_off_path = conf->get_conf();
-    else
+    if (!CONFIDENCE_ENABLE)
       op->conf_off_path = FALSE;
 
     cur_op = op;
@@ -432,11 +430,6 @@ void Decoupled_FE::update() {
       cfs_taken_this_cycle += cf_taken || bar_fetch;
     }
 
-    if (CONFIDENCE_ENABLE) {
-      // update confidence
-      conf->update(op, ft_ended_by != FT_NOT_ENDED);
-    }
-
     current_ft_to_push.add_op(op, ft_ended_by);
     // ft_ended_by != FT_NOT_ENDED indicates the end of the current fetch target
     // it is now ready to be pushed to the queue
@@ -460,6 +453,9 @@ void Decoupled_FE::update() {
         }
       }
       ftq.emplace_back(current_ft_to_push);
+      if (CONFIDENCE_ENABLE) {
+        conf->update(current_ft_to_push);
+      }
       current_ft_to_push = FT(proc_id);
       if (ft_ended_by == FT_ICACHE_LINE_BOUNDARY) {
         current_ft_to_push.set_ft_started_by(FT_STARTED_BY_ICACHE_LINE_BOUNDARY);


### PR DESCRIPTION
#### Summary
This refactor changes how the confidence mechansim interacts with the decoupled frontend. Instead of calling `conf->update()` for every op as the decoupled frontend builds an FT, `conf->update()` is now called when an FT is completed. The FT is passed to the update, and the confidence mechanism iterates through the ops within the FT internally. It also includes a couple fixes to the per_cycle update of confidence.