### PR TITLE
Select Confidence Mechanism with Enum

### DIFF
--- a/src/confidence/conf.cc
+++ b/src/confidence/conf.cc
@@ -124,11 +124,11 @@ void ConfMechStatBase::set_prev_op(Op* op) {
 
 /* Conf member functions */
 Conf::Conf(uns _proc_id) : proc_id(_proc_id), conf_off_path(false), last_cycle_count(0) {
-  if (CONF_BTB_MISS_BP_TAKEN)
+  if (CONFIDENCE_MECH == CONF_MECH_BTB_MISS_BP_TAKEN)
     conf_mech = new BTBMissBPTakenConf(_proc_id);
-  else if (CONF_PERCEPTRON_CONF)
+  else if (CONFIDENCE_MECH == CONF_MECH_PERCEPTRON)
     conf_mech = new PerceptronConf(_proc_id);
-  else
+  else if (CONFIDENCE_MECH == CONF_MECH_WEIGHT)
     conf_mech = new WeightConf(_proc_id);
 }
 

--- a/src/confidence/conf.hpp
+++ b/src/confidence/conf.hpp
@@ -34,6 +34,12 @@
 #include "decoupled_frontend.h"
 #include "ft.h"
 
+typedef enum Confidence_Mechanism_enum {
+  CONF_MECH_WEIGHT,
+  CONF_MECH_PERCEPTRON,
+  CONF_MECH_BTB_MISS_BP_TAKEN,
+} Confidence_Mechanism;
+
 class ConfMechBase;  // forward declaration
 
 class ConfMechStatBase {

--- a/src/core.param.def
+++ b/src/core.param.def
@@ -329,11 +329,11 @@ DEF_PARAM(trace_buf_size, TRACE_BUF_SIZE, uns, uns, 0, )
 
 DEF_PARAM(perfect_confidence, PERFECT_CONFIDENCE, Flag, Flag, FALSE, )
 DEF_PARAM(confidence_enable, CONFIDENCE_ENABLE, Flag, Flag, FALSE, )
+DEF_PARAM(confidence_mech, CONFIDENCE_MECH, uns, uns, 0, ) // 0 = weight, 1 = perceptron, 2 = btb_miss_bp_taken
 // Flag for this for perf reasons
 DEF_PARAM(conf_walk_ftq_on_flush, CONF_WALK_FTQ_ON_FLUSH, Flag, Flag, FALSE, )
 DEF_PARAM(conf_off_path_threshold, CONF_OFF_PATH_THRESHOLD, uns, uns, 15, )
 DEF_PARAM(conf_off_path_inc, CONF_OFF_PATH_INC, uns, uns, 5, )
-DEF_PARAM(conf_btb_miss_bp_taken, CONF_BTB_MISS_BP_TAKEN, Flag, Flag, FALSE, )
 DEF_PARAM(conf_ipc_rate_conf, CONF_IPC_RATE_CONF, Flag, Flag, FALSE, )
 DEF_PARAM(conf_btb_miss_bp_taken_threshold, CONF_BTB_MISS_BP_TAKEN_THRESHOLD, int, int, 0, )
 DEF_PARAM(conf_btb_miss_rate_cycles_threshold, CONF_BTB_MISS_RATE_CYCLES_THRESHOLD, float, float, 1.0, )
@@ -366,7 +366,6 @@ DEF_PARAM(conf_log_dfe_to_rec, CONF_LOG_DFE_TO_REC, Flag, Flag, FALSE, )
 DEF_PARAM(conf_log_phase_cycles, CONF_LOG_PHASE_CYCLES, Flag, Flag, FALSE, )
 
 // Perceptron Conf Parameters
-DEF_PARAM(conf_perceptron_conf, CONF_PERCEPTRON_CONF, Flag, Flag, FALSE, )
 DEF_PARAM(conf_perceptron_threshold, CONF_PERCEPTRON_THRESHOLD, float, float, 0.0, )
 DEF_PARAM(conf_perceptron_lr, PATH_CONF_PERCEPTRON_LR, float, float, 0.5, )
 DEF_PARAM(conf_n_perceptrons, PATH_CONF_N_PERCEPTRONS, uns, uns, 32, )

--- a/src/sim.c
+++ b/src/sim.c
@@ -701,7 +701,7 @@ void full_sim() {
       if (!sim_done[proc_id] && (retired_exit[proc_id] || reachedInstLimit)) {
         if (model->per_core_done_func)
           model->per_core_done_func(proc_id);
-        if (CONFIDENCE_ENABLE && (CONF_PERCEPTRON_CONF || CONF_LOG_DFE_TO_REC || CONF_LOG_PHASE_CYCLES)) {
+        if (CONFIDENCE_ENABLE && (CONF_PRINT_PERCEPTRON_WEIGHTS || CONF_LOG_DFE_TO_REC || CONF_LOG_PHASE_CYCLES)) {
           decoupled_fe_print_conf_data();
         }
         if (FDIP_ENABLE) {


### PR DESCRIPTION
#### Summary
This PR removes parameters that enable each confidence mechanism and replaces them with a single parameter that takes an unsigned int. The values corresponding to each mechanism are defined in the `Confidence_Mech` enum in Conf.hpp.
