### PR TITLE
[REFACTOR] Physical Issue Queue Implementation of Random Organization

### DIFF
--- a/src/cmp_model.c
+++ b/src/cmp_model.c
@@ -58,6 +58,7 @@
 #include "freq.h"
 #include "ft.h"
 #include "idq_stage.h"
+#include "issue_queue.h"
 #include "lsq.h"
 #include "map_rename.h"
 #include "op_pool.h"
@@ -158,7 +159,6 @@ void cmp_init(uns mode) {
     dvfs_init();
 
   cache_part_init();
-
 }
 
 /**************************************************************************************/
@@ -358,6 +358,7 @@ void cmp_wake(Op* src_op, Op* dep_op, uns rdy_bit) {
     dep_op->next_rdy = node->rdy_head;
     node->rdy_head = dep_op;
     dep_op->in_rdy_list = TRUE;
+    issue_queue_wakeup(dep_op);
   }
 }
 
@@ -393,6 +394,7 @@ void cmp_recover() {
   recover_idq_stage();
   recover_map_stage();
   recover_lsq();
+  recover_issue_queue();
   recover_exec_stage();
   recover_dcache_stage();
   recover_memory();

--- a/src/cmp_model_support.c
+++ b/src/cmp_model_support.c
@@ -42,6 +42,7 @@
 #include "prefetcher/fdip.h"
 
 #include "cmp_model.h"
+#include "issue_queue.h"
 #include "lookahead_buffer.h"
 #include "lsq.h"
 #include "statistics.h"
@@ -78,6 +79,7 @@ void cmp_init_cmp_model() {
   alloc_mem_uop_queue_stage(NUM_CORES);
   alloc_mem_idq_stage(NUM_CORES);
   alloc_mem_lsq(NUM_CORES);
+  alloc_mem_issue_queue(NUM_CORES);
 }
 
 void cmp_init_thread_data(uns8 proc_id) {
@@ -103,6 +105,7 @@ void cmp_set_all_stages(uns8 proc_id) {
   set_map_stage(&cmp_model.map_stage[proc_id]);
   set_node_stage(&cmp_model.node_stage[proc_id]);
   set_lsq(proc_id);
+  set_issue_queue(proc_id);
   set_exec_stage(&cmp_model.exec_stage[proc_id]);
   set_dcache_stage(&cmp_model.dcache_stage[proc_id]);
 }

--- a/src/core.param.def
+++ b/src/core.param.def
@@ -162,6 +162,8 @@ DEF_PARAM(node_issue_queue_dispatch_scheme, NODE_ISSUE_QUEUE_DISPATCH_SCHEME, un
  */
 DEF_PARAM(node_issue_queue_schedule_scheme, NODE_ISSUE_QUEUE_SCHEDULE_SCHEME, uns, uns, 0, )
 
+DEF_PARAM(issue_queue_parallel_pick, ISSUE_QUEUE_PARALLEL_PICK, Flag, Flag, FALSE, )
+
 /********EXEC PORT
  * PARAMETERS*********************************************************/
 /*Size of each RS, length should be NUM_RS, Must be type string since it is an

--- a/src/exec_stage.c
+++ b/src/exec_stage.c
@@ -308,7 +308,7 @@ void update_exec_stage(Stage_Data* src_sd) {
     STAT_EVENT(exec->proc_id, FUS_BUSY_ON_PATH + op->off_path);
 
     /* remove the op from the "schedule" list */
-    issue_queue_grant(op);
+    issue_queue_issued(op);
     src_sd->ops[ii] = NULL;
     src_sd->op_count--;
     ASSERT(exec->proc_id, src_sd->op_count >= 0);

--- a/src/exec_stage.c
+++ b/src/exec_stage.c
@@ -51,6 +51,7 @@
 
 #include "cmp_model.h"
 #include "exec_ports.h"
+#include "issue_queue.h"
 #include "map.h"
 #include "map_rename.h"
 #include "statistics.h"
@@ -307,6 +308,7 @@ void update_exec_stage(Stage_Data* src_sd) {
     STAT_EVENT(exec->proc_id, FUS_BUSY_ON_PATH + op->off_path);
 
     /* remove the op from the "schedule" list */
+    issue_queue_grant(op);
     src_sd->ops[ii] = NULL;
     src_sd->op_count--;
     ASSERT(exec->proc_id, src_sd->op_count >= 0);
@@ -477,6 +479,7 @@ static inline void exec_stage_dep_wakeup(Op* op) {
 static inline void exec_stage_reject_op(Stage_Data* src_sd, int ii, int event) {
   Op* op = src_sd->ops[ii];
 
+  issue_queue_reject(op);
   src_sd->ops[ii] = NULL;
   src_sd->op_count--;
 

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -51,8 +51,6 @@ extern "C" {
 #include <deque>
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 /**************************************************************************************/
@@ -109,7 +107,6 @@ struct IssueQueueEntry {
   Op* op = nullptr;
   uns64 op_fu_type = 0;
   ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
-  IssueQueueEntry* next_ready = nullptr;
 
   explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
   void clear();
@@ -119,7 +116,6 @@ struct IssueQueueEntry {
 void IssueQueueEntry::clear() {
   op = nullptr;
   op_fu_type = 0;
-  ASSERT(node->proc_id, next_ready == nullptr);
 }
 
 void IssueQueueEntry::fill(Op* op) {
@@ -184,14 +180,17 @@ class FunctionalUnitPicker {
   const uns32 fu_id;
   const uns64 fu_type;
 
+  std::unique_ptr<SchedulePolicy> sched_policy;
+
   // current selection for this cycle
   IssueQueueEntry* picked_entry = nullptr;
 
  public:
-  explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
-      : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
+  explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type,
+                                std::unique_ptr<SchedulePolicy> sched_policy)
+      : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type), sched_policy(std::move(sched_policy)) {}
 
-  void pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy);
+  void pick(IssueQueueEntry*& candidate);
   void grant();
   bool is_compatible(uns64 op_fu_type) const;
 
@@ -203,10 +202,8 @@ class FunctionalUnitPicker {
  * selection, it replaces the existing selection according to the
  * scheduling policy.
  */
-void FunctionalUnitPicker::pick(IssueQueueEntry*& request_entry, const SchedulePolicy& sched_policy) {
-  ASSERT(node->proc_id, request_entry != nullptr);
-  bool replace = (picked_entry == nullptr || sched_policy.compare(request_entry, picked_entry));
-  if (!replace) {
+void FunctionalUnitPicker::pick(IssueQueueEntry*& request_entry) {
+  if (!(picked_entry == nullptr || sched_policy->compare(request_entry, picked_entry))) {
     return;
   }
 
@@ -266,27 +263,21 @@ class SelectLogic {
   const uns16 queue_id;
 
   std::vector<FunctionalUnitPicker> connected_fu_pickers;
-  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;  // per-picker scheduling policies
-  std::unique_ptr<ArbitrationPolicy> arbitration_policy;        // picker traversal policy for the current cycle
+  std::unique_ptr<ArbitrationPolicy> arbitration_policy;
 
-  std::vector<size_t> picker_order;       // picker traversal order generated each cycle
-  IssueQueueEntry* ready_head = nullptr;  // head of the unsorted ready request list
-  uns64 ready_op_types = 0;               // bitmask of ready op types in this cycle
+  std::vector<size_t> picker_order;  // picker traversal order generated each cycle
+  uns64 ready_op_types = 0;          // bitmask of ready op types in this cycle
 
  public:
-  explicit SelectLogic(uns proc_id, uns16 queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
-                       std::vector<std::unique_ptr<SchedulePolicy>> sched_policies,
+  explicit SelectLogic(uns proc_id, uns16 queue_id, std::vector<FunctionalUnitPicker> connected_fu_pickers,
                        std::unique_ptr<ArbitrationPolicy> arbitration_policy)
       : proc_id(proc_id),
         queue_id(queue_id),
-        connected_fu_pickers(connected_fu_pickers),
-        sched_policies(std::move(sched_policies)),
+        connected_fu_pickers(std::move(connected_fu_pickers)),
         arbitration_policy(std::move(arbitration_policy)),
         picker_order(this->connected_fu_pickers.size()) {}
 
-  void select();
-  void request(IssueQueueEntry* entry);
-  void release(IssueQueueEntry* entry);
+  void select(std::vector<IssueQueueEntry>& entries);
 };
 
 /*
@@ -297,22 +288,22 @@ class SelectLogic {
  * Parallel selection allows each functional unit to independently select a ready op in the same cycle.
  * An arbitrator is then used to resolve conflicts when multiple functional units select the same op.
  */
-void SelectLogic::select() {
+void SelectLogic::select(std::vector<IssueQueueEntry>& entries) {
   const size_t fu_num = connected_fu_pickers.size();
   arbitration_policy->build_picker_order(picker_order);
   ready_op_types = 0;
 
-  for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
+  for (IssueQueueEntry& entry : entries) {
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
-    if (entry->state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry->op)) {
+    if (entry.state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry.op)) {
       continue;
     }
 
     // track the ready op types for stat collection
-    ready_op_types |= entry->op_fu_type;
+    ready_op_types |= entry.op_fu_type;
 
     // the current request propagated through the serial picker chain
-    IssueQueueEntry* request_entry = entry;
+    IssueQueueEntry* request_entry = &entry;
 
     for (size_t i = 0; i < fu_num; ++i) {
       // traverse pickers in arbitration order
@@ -322,7 +313,7 @@ void SelectLogic::select() {
       if (!fu_picker.is_compatible(request_entry->op_fu_type)) {
         continue;
       }
-      fu_picker.pick(request_entry, *sched_policies[picker_idx]);
+      fu_picker.pick(request_entry);
 
       // the request has been consumed
       if (request_entry == nullptr) {
@@ -355,33 +346,6 @@ void SelectLogic::select() {
       STAT_EVENT(node->proc_id, FU_IDLE_NO_READY_OPS_TOTAL);
       STAT_EVENT(node->proc_id, FU_0_IDLE_NO_READY_OPS + (fu_id < 32 ? fu_id : 32));
     }
-  }
-}
-
-void SelectLogic::request(IssueQueueEntry* entry) {
-  ASSERT(node->proc_id, entry->next_ready == nullptr);
-  entry->next_ready = ready_head;
-  ready_head = entry;
-}
-
-void SelectLogic::release(IssueQueueEntry* entry) {
-  IssueQueueEntry* prev = nullptr;
-  IssueQueueEntry* curr = ready_head;
-  while (curr != nullptr) {
-    if (curr != entry) {
-      prev = curr;
-      curr = curr->next_ready;
-      continue;
-    }
-
-    if (prev == nullptr) {
-      ready_head = curr->next_ready;
-    } else {
-      prev->next_ready = curr->next_ready;
-    }
-
-    curr->next_ready = nullptr;
-    return;
   }
 }
 
@@ -424,16 +388,8 @@ void RoundRobinArbitrationPolicy::build_picker_order(std::vector<size_t>& picker
 
 class IssueQueuePolicyFactory {
  public:
-  std::vector<std::unique_ptr<SchedulePolicy>> make_schedule_policies(
-      const std::vector<FunctionalUnitPicker>& fu_pickers) {
-    std::vector<std::unique_ptr<SchedulePolicy>> policies;
-    policies.reserve(fu_pickers.size());
-
-    for (size_t i = 0; i < fu_pickers.size(); i++) {
-      policies.emplace_back(std::make_unique<OldestFirstSchedulePolicy>());
-    }
-
-    return policies;
+  std::unique_ptr<SchedulePolicy> make_schedule_policy(uns16 queue_id, uns32 fu_id, uns64 fu_type) {
+    return std::make_unique<OldestFirstSchedulePolicy>();
   }
 
   std::unique_ptr<ArbitrationPolicy> make_arbitration_policy(size_t fu_num) {
@@ -457,8 +413,7 @@ class IssueQueue {
   std::unique_ptr<SelectLogic> select_logic;
 
  public:
-  explicit IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
-                      const std::vector<FunctionalUnitPicker>& connected_fu_pickers);
+  explicit IssueQueue(uns proc_id, uns16 queue_id, uns16 size, std::vector<FunctionalUnitPicker> connected_fu_pickers);
   uns16 allocate_entry(Op* op);
   void free_entry(uns16 entry_id);
   size_t available_entries() const { return free_list.size(); }
@@ -472,8 +427,7 @@ class IssueQueue {
   void schedule();
 };
 
-IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
-                       const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
+IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size, std::vector<FunctionalUnitPicker> connected_fu_pickers)
     : proc_id(proc_id), queue_id(queue_id) {
   // initialize entries and free list
   entries.reserve(size);
@@ -485,8 +439,7 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
 
   // initialize select logic from the scheduling and arbitration policies.
   IssueQueuePolicyFactory factory;
-  select_logic = std::make_unique<SelectLogic>(proc_id, queue_id, connected_fu_pickers,
-                                               factory.make_schedule_policies(connected_fu_pickers),
+  select_logic = std::make_unique<SelectLogic>(proc_id, queue_id, std::move(connected_fu_pickers),
                                                factory.make_arbitration_policy(connected_fu_pickers.size()));
 }
 
@@ -524,7 +477,6 @@ void IssueQueue::wakeup(uns16 entry_id) {
 
   op->in_rdy_list = TRUE;
   entry.state = ISSUE_QUEUE_ENTRY_STATE_READY;
-  select_logic->request(&entry);
 }
 
 void IssueQueue::issued(uns16 entry_id) {
@@ -537,7 +489,6 @@ void IssueQueue::issued(uns16 entry_id) {
 
   STAT_EVENT(node->proc_id, OP_ISSUED);
   op->in_rdy_list = FALSE;
-  select_logic->release(&entry);
   free_entry(entry.entry_id);
 }
 
@@ -561,13 +512,12 @@ void IssueQueue::recover() {
     }
 
     op->in_rdy_list = FALSE;
-    select_logic->release(&entry);
     free_entry(entry.entry_id);
   }
 }
 
 void IssueQueue::schedule() {
-  select_logic->select();
+  select_logic->select(entries);
 }
 
 /**************************************************************************************/
@@ -624,9 +574,9 @@ IssueQueues::IssueQueues(uns proc_id) : proc_id(proc_id) {
   fu_map.assign(NUM_FUS, MAX_UNS16);
   for (size_t i = 0; i < NUM_RS; ++i) {
     for (uns64 mask = parse_mask(connection_tokens[i]); mask; mask &= (mask - 1)) {
-      int idx = __builtin_ctzll(mask);
-      ASSERT(proc_id, idx < (int)NUM_FUS);
-      fu_map[idx] = i;
+      int fu_id = __builtin_ctzll(mask);
+      ASSERT(proc_id, fu_id < (int)NUM_FUS && fu_map[fu_id] == MAX_UNS16);
+      fu_map[fu_id] = i;
     }
   }
 
@@ -635,11 +585,15 @@ IssueQueues::IssueQueues(uns proc_id) : proc_id(proc_id) {
   ASSERT(proc_id, fu_tokens.size() == NUM_FUS);
   std::vector<std::vector<FunctionalUnitPicker>> fu_connection(NUM_RS);
   fu_types.assign(NUM_RS, 0);
+  IssueQueuePolicyFactory factory;
   for (size_t i = 0; i < NUM_FUS; ++i) {
+    uns16 queue_id = fu_map[i];
+    ASSERT(proc_id, queue_id != MAX_UNS16);
     uns64 fu_type = parse_mask(fu_tokens[i]);
-    fu_connection[fu_map[i]].emplace_back(proc_id, fu_map[i], i, fu_type);
-    fu_types[fu_map[i]] |= fu_type;
-    DEBUG(proc_id, "FU %ld, queue: %d, type: 0x%llx\n", i, fu_map[i], fu_type);
+    fu_connection[queue_id].emplace_back(proc_id, queue_id, i, fu_type,
+                                         factory.make_schedule_policy(queue_id, i, fu_type));
+    fu_types[queue_id] |= fu_type;
+    DEBUG(proc_id, "FU %ld, queue: %d, type: 0x%llx\n", i, queue_id, fu_type);
   }
 
   // create issue queues based on configuration
@@ -648,7 +602,7 @@ IssueQueues::IssueQueues(uns proc_id) : proc_id(proc_id) {
   for (uns16 i = 0; i < NUM_RS; ++i) {
     char* end = nullptr;
     uns64 size = strtoull(p, &end, 10);
-    issue_queues.emplace_back(proc_id, i, size, fu_connection[i]);
+    issue_queues.emplace_back(proc_id, i, size, std::move(fu_connection[i]));
     p = end;
   }
 }

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -49,7 +49,6 @@ extern "C" {
 }
 
 #include <deque>
-#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -81,6 +80,7 @@ struct IssueQueueEntry {
 
   Op* op = nullptr;
   ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
+  IssueQueueEntry* next_ready = nullptr;
 
   explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
   void clear();
@@ -96,6 +96,30 @@ void IssueQueueEntry::fill(Op* op) {
 }
 
 /**************************************************************************************/
+/* Virtual Interface */
+
+// SchedulePolicy is responsible for deciding the priority of picking
+class SchedulePolicy {
+ public:
+  virtual ~SchedulePolicy() = default;
+
+  // Return if the lhs entry is the preference
+  virtual bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const = 0;
+};
+
+// ArbitrationPolicy is responsible for determining the picker order
+class ArbitrationPolicy {
+ public:
+  virtual ~ArbitrationPolicy() = default;
+
+  // Prepare the picker order for the current selection cycle
+  virtual void prepare_picker_order() = 0;
+
+  // Get the picker index at the given index in the current order
+  virtual size_t picker_at(size_t i) const = 0;
+};
+
+/**************************************************************************************/
 
 struct FunctionalUnitPicker {
  private:
@@ -104,60 +128,54 @@ struct FunctionalUnitPicker {
   const uns32 fu_id;
   const uns64 fu_type;
 
-  using ReadyList = std::map<Counter, IssueQueueEntry*>;
-  using ReadyIter = ReadyList::iterator;
-  ReadyList ready_list;
-  ReadyIter ready_iter;
-
   Flag check_op_ready(Op* op) const;
 
  public:
   explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
       : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
 
-  IssueQueueEntry* pick_next(const std::unordered_set<Counter>& picked_mask);
-  void grant_op(IssueQueueEntry* entry);
-
-  bool is_compatible(Inst_Info* inst_info) const {
-    return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
-  }
-  void add_ready_entry(uns64 key, IssueQueueEntry* entry) { ready_list[key] = entry; }
-  void remove_ready_entry(uns64 key) { ready_list.erase(key); }
-  void init_ready_iter() { ready_iter = ready_list.begin(); }
+  IssueQueueEntry* pick(IssueQueueEntry* ready_head, const std::unordered_set<uns16>& picked_mask,
+                        const SchedulePolicy& sched_policy);
+  void grant(IssueQueueEntry* entry);
+  bool is_compatible(Inst_Info* inst_info) const;
 };
 
-IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& picked_mask) {
-  while (ready_iter != ready_list.end()) {
-    IssueQueueEntry* entry = ready_iter->second;
-    Op* op = entry->op;
-    ++ready_iter;
-
+IssueQueueEntry* FunctionalUnitPicker::pick(IssueQueueEntry* ready_head, const std::unordered_set<uns16>& picked_mask,
+                                            const SchedulePolicy& sched_policy) {
+  IssueQueueEntry* ret = nullptr;
+  for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
     if (entry->state == ISSUE_QUEUE_ENTRY_STATE_PICKED) {
-      /*
-       * Conflict with another picker in the same round (parallel selection).
-       * This picker is unaware of current-round selections and loses arbitration.
-       * The selection is cancelled and deferred to the next round.
-       */
-      if (picked_mask.count(entry->entry_id)) {
-        return nullptr;
-      }
+      continue;
+    }
 
+    if (!is_compatible(entry->op->inst_info)) {
       continue;
     }
 
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
-    if (!check_op_ready(op)) {
+    if (!check_op_ready(entry->op)) {
       continue;
     }
 
-    ASSERT(proc_id, node->sd.ops[fu_id] == nullptr && is_compatible(op->inst_info));
-    return entry;
+    ASSERT(proc_id, node->sd.ops[fu_id] == nullptr);
+    if (ret == nullptr || sched_policy.compare(entry, ret)) {
+      ret = entry;
+    }
   }
 
-  return nullptr;
+  /*
+   * Conflict with another picker in the same round (parallel selection).
+   * This picker is unaware of current-round selections and loses arbitration.
+   * The selection is cancelled and deferred to the next round.
+   */
+  if (ret != nullptr && picked_mask.count(ret->entry_id)) {
+    return nullptr;
+  }
+
+  return ret;
 }
 
-void FunctionalUnitPicker::grant_op(IssueQueueEntry* entry) {
+void FunctionalUnitPicker::grant(IssueQueueEntry* entry) {
   Op* op = entry->op;
   ASSERT(proc_id, op != nullptr);
   ASSERT(proc_id, fu_id < (uns32)node->sd.max_op_count && node->sd.ops[fu_id] == nullptr);
@@ -169,6 +187,10 @@ void FunctionalUnitPicker::grant_op(IssueQueueEntry* entry) {
   node->sd.op_count += 1;
 
   entry->state = ISSUE_QUEUE_ENTRY_STATE_PICKED;
+}
+
+bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
+  return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
 }
 
 Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
@@ -197,30 +219,6 @@ Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
 }
 
 /**************************************************************************************/
-/* Virtual Interface */
-
-// SchedulePolicy is responsible for deciding the sequence of the ready list.
-class SchedulePolicy {
- public:
-  virtual ~SchedulePolicy() = default;
-
-  // Return the key of the entry of the sorted ready list
-  virtual Counter get_key(IssueQueueEntry* entry) = 0;
-};
-
-// ArbitrationPolicy is responsible for determining the picker order
-class ArbitrationPolicy {
- public:
-  virtual ~ArbitrationPolicy() = default;
-
-  // Prepare the picker order for the current selection cycle
-  virtual void prepare_picker_order() = 0;
-
-  // Get the picker index at the given index in the current order
-  virtual size_t picker_at(size_t i) = 0;
-};
-
-/**************************************************************************************/
 /*
  * The select logic is responsible for picking ready ops from the wakeup logic in the issue queue.
  * It is composed of a SchedulePolicy (in what order of ready lists) and an ArbitrationPolicy (in what order to pick).
@@ -231,6 +229,7 @@ class SelectLogic {
   std::vector<FunctionalUnitPicker> connected_fu_pickers;
   std::unique_ptr<SchedulePolicy> sched_policy;
   std::unique_ptr<ArbitrationPolicy> arbitration_policy;
+  IssueQueueEntry* ready_head = nullptr;
 
  public:
   SelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
@@ -257,60 +256,64 @@ void SelectLogic::select() {
   const size_t fu_num = connected_fu_pickers.size();
   arbitration_policy->prepare_picker_order();
 
-  // reset the ready iter for each picker to start from the head of the ready list
-  for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    fu_picker.init_ready_iter();
-  }
-
-  std::unordered_set<Counter> picked_mask;
+  std::unordered_set<uns16> picked_mask;
   for (size_t i = 0; i < fu_num; ++i) {
     FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
-    IssueQueueEntry* entry = fu_picker.pick_next(picked_mask);
+    IssueQueueEntry* entry = fu_picker.pick(ready_head, picked_mask, *sched_policy);
 
-    // do the picking in the next round if it is cancelled due to a conflict in the same round
+    // if the picking is cancelled due to a conflict in the same round or there is no compatible entry
     if (entry == nullptr) {
       continue;
     }
 
-    // mark the current pickas the winner to cancel competing picks for the same op in this round
+    // mark the current pick as the winner to cancel competing picks for the same op in this round
     if (ISSUE_QUEUE_PARALLEL_PICK) {
       picked_mask.insert(entry->entry_id);
     }
 
-    fu_picker.grant_op(entry);
+    // issue the op into the stage_data
+    fu_picker.grant(entry);
   }
 }
 
 void SelectLogic::request(IssueQueueEntry* entry) {
-  uns64 key = sched_policy->get_key(entry);
-  for (size_t i = 0; i < connected_fu_pickers.size(); ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    if (fu_picker.is_compatible(entry->op->inst_info)) {
-      fu_picker.add_ready_entry(key, entry);
-    }
-  }
+  ASSERT(node->proc_id, entry->next_ready == nullptr);
+  entry->next_ready = ready_head;
+  ready_head = entry;
 }
 
 void SelectLogic::release(IssueQueueEntry* entry) {
-  uns64 key = sched_policy->get_key(entry);
-  for (size_t i = 0; i < connected_fu_pickers.size(); ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    fu_picker.remove_ready_entry(key);
+  IssueQueueEntry* prev = nullptr;
+  IssueQueueEntry* curr = ready_head;
+  while (curr != nullptr) {
+    if (curr != entry) {
+      prev = curr;
+      curr = curr->next_ready;
+      continue;
+    }
+
+    if (prev == nullptr) {
+      ready_head = curr->next_ready;
+    } else {
+      prev->next_ready = curr->next_ready;
+    }
+
+    curr->next_ready = nullptr;
+    return;
   }
 }
 
 /**************************************************************************************/
 /* Implementation */
 
-// OldestFirstSchedulePolicy keeps the ready list of each picker sorted by op age.
+// OldestFirstSchedulePolicy prioritize the older ops
 class OldestFirstSchedulePolicy : public SchedulePolicy {
  public:
-  Counter get_key(IssueQueueEntry* entry) override;
+  bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const override;
 };
 
-Counter OldestFirstSchedulePolicy::get_key(IssueQueueEntry* entry) {
-  return entry->op->op_num;
+bool OldestFirstSchedulePolicy::compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const {
+  return lhs->op->op_num < rhs->op->op_num;
 }
 
 // RoundRobinArbitrationPolicy ensures fairness by rotating through pickers in a circular manner.
@@ -322,14 +325,14 @@ class RoundRobinArbitrationPolicy : public ArbitrationPolicy {
  public:
   explicit RoundRobinArbitrationPolicy(size_t fu_num) : fu_num(fu_num), fu_idx(fu_num - 1) {}
   void prepare_picker_order() override;
-  size_t picker_at(size_t i) override;
+  size_t picker_at(size_t i) const override;
 };
 
 void RoundRobinArbitrationPolicy::prepare_picker_order() {
   fu_idx = (fu_idx + 1) % fu_num;
 }
 
-size_t RoundRobinArbitrationPolicy::picker_at(size_t i) {
+size_t RoundRobinArbitrationPolicy::picker_at(size_t i) const {
   return (fu_idx + i) % fu_num;
 }
 
@@ -722,6 +725,7 @@ void issue_queue_update() {
 }
 
 void issue_queue_wakeup(Op* op) {
+  // wake up ops and insert them into the ready list for scheduling
   issue_queues->wakeup(op);
 }
 

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -132,8 +132,8 @@ struct FunctionalUnitPicker {
   bool is_compatible(Inst_Info* inst_info) const {
     return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
   }
-  void add_ready_entry(Counter key, IssueQueueEntry* entry) { ready_list[key] = entry; }
-  void remove_ready_entry(Counter key) { ready_list.erase(key); }
+  void add_ready_entry(uns64 key, IssueQueueEntry* entry) { ready_list[key] = entry; }
+  void remove_ready_entry(uns64 key) { ready_list.erase(key); }
   void init_ready_iter() { ready_iter = ready_list.begin(); }
 };
 
@@ -208,25 +208,52 @@ Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
 }
 
 /**************************************************************************************/
+/* Virtual Interface */
+
+// SchedulePolicy is responsible for deciding the sequence of the ready list.
+class SchedulePolicy {
+ public:
+  virtual ~SchedulePolicy() = default;
+
+  // Return the key of the entry of the sorted ready list
+  virtual Counter get_key(IssueQueueEntry* entry) = 0;
+};
+
+// ArbitrationPolicy is responsible for determining the picker order
+class ArbitrationPolicy {
+ public:
+  virtual ~ArbitrationPolicy() = default;
+
+  // Prepare the picker order for the current selection cycle
+  virtual void prepare_picker_order() = 0;
+
+  // Get the picker index at the given index in the current order
+  virtual size_t picker_at(size_t i) = 0;
+};
+
+/**************************************************************************************/
 /*
  * The select logic is responsible for picking ready ops from the wakeup logic in the issue queue.
- * Since the issue queue is organized in a non-ordered (random) manner, the select logic typically relies
- * on an age matrix to track the relative age of entries.
+ * It is composed of a SchedulePolicy (in what order of ready lists) and an ArbitrationPolicy (in what order to pick).
  */
 
 class SelectLogic {
+ protected:
+  std::vector<FunctionalUnitPicker> connected_fu_pickers;
+  std::unique_ptr<SchedulePolicy> sched_policy;
+  std::unique_ptr<ArbitrationPolicy> arbitration_policy;
+
  public:
+  SelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
+              std::unique_ptr<SchedulePolicy> sched_policy, std::unique_ptr<ArbitrationPolicy> arbitration_policy)
+      : connected_fu_pickers(connected_fu_pickers),
+        sched_policy(std::move(sched_policy)),
+        arbitration_policy(std::move(arbitration_policy)) {}
   virtual ~SelectLogic() = default;
 
   void select();
-  virtual void request(IssueQueueEntry* entry) = 0;
-  virtual void release(IssueQueueEntry* entry) = 0;
-
- protected:
-  // helper methods for select logic to interact with the pickers
-  virtual void prepare_picker_order() = 0;
-  virtual FunctionalUnitPicker& picker_at(size_t i) = 0;
-  virtual size_t picker_count() const = 0;
+  void request(IssueQueueEntry* entry);
+  void release(IssueQueueEntry* entry);
 };
 
 /*
@@ -237,14 +264,13 @@ class SelectLogic {
  * Parallel selection allows each functional unit to independently select a ready op in the same cycle.
  * An arbitrator is then used to resolve conflicts when multiple functional units select the same op.
  */
-
 void SelectLogic::select() {
-  const size_t fu_num = picker_count();
-  prepare_picker_order();
+  const size_t fu_num = connected_fu_pickers.size();
+  arbitration_policy->prepare_picker_order();
 
   // reset the ready iter for each picker to start from the head of the ready list
   for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = picker_at(i);
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
     fu_picker.init_ready_iter();
   }
 
@@ -260,7 +286,7 @@ void SelectLogic::select() {
         continue;
       }
 
-      FunctionalUnitPicker& fu_picker = picker_at(i);
+      FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
       auto ret = fu_picker.pick_next(cancelled_mask);
 
       // mark the picker inactive if the iterator reaches the end of the ready list
@@ -285,57 +311,69 @@ void SelectLogic::select() {
   }
 }
 
-/**************************************************************************************/
-
-class RoundRobinOldestFirstSelectLogic : public SelectLogic {
- private:
-  const uns queue_id;
-  const size_t fu_num;
-  int fu_idx = 0;  // circular queue idx for round-robin selection
-  std::vector<FunctionalUnitPicker> connected_fu_pickers;
-
- public:
-  RoundRobinOldestFirstSelectLogic(uns queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
-      : queue_id(queue_id),
-        fu_num(connected_fu_pickers.size()),
-        fu_idx(fu_num - 1),
-        connected_fu_pickers(connected_fu_pickers) {}
-  void request(IssueQueueEntry* entry) override;
-  void release(IssueQueueEntry* entry) override;
-
- protected:
-  void prepare_picker_order() override;
-  FunctionalUnitPicker& picker_at(size_t i) override;
-  size_t picker_count() const override { return fu_num; }
-};
-
-// oldest-first policy keeps the ready list of each picker sorted by op age
-void RoundRobinOldestFirstSelectLogic::request(IssueQueueEntry* entry) {
-  for (size_t i = 0; i < fu_num; ++i) {
+void SelectLogic::request(IssueQueueEntry* entry) {
+  uns64 key = sched_policy->get_key(entry);
+  for (size_t i = 0; i < connected_fu_pickers.size(); ++i) {
     FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
     if (fu_picker.is_compatible(entry->op->inst_info)) {
-      fu_picker.add_ready_entry(entry->op->op_num, entry);
+      fu_picker.add_ready_entry(key, entry);
     }
   }
 }
 
-void RoundRobinOldestFirstSelectLogic::release(IssueQueueEntry* entry) {
-  for (size_t i = 0; i < fu_num; ++i) {
+void SelectLogic::release(IssueQueueEntry* entry) {
+  uns64 key = sched_policy->get_key(entry);
+  for (size_t i = 0; i < connected_fu_pickers.size(); ++i) {
     FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    fu_picker.remove_ready_entry(entry->op->op_num);
+    fu_picker.remove_ready_entry(key);
   }
 }
 
-// round-robin mechanism is used to ensure fairness
-void RoundRobinOldestFirstSelectLogic::prepare_picker_order() {
+/**************************************************************************************/
+/* Implementation */
+
+// OldestFirstSchedulePolicy keeps the ready list of each picker sorted by op age.
+class OldestFirstSchedulePolicy : public SchedulePolicy {
+ public:
+  Counter get_key(IssueQueueEntry* entry) override;
+};
+
+Counter OldestFirstSchedulePolicy::get_key(IssueQueueEntry* entry) {
+  return entry->op->op_num;
+}
+
+// RoundRobinArbitrationPolicy ensures fairness by rotating through pickers in a circular manner.
+class RoundRobinArbitrationPolicy : public ArbitrationPolicy {
+ private:
+  const size_t fu_num;
+  int fu_idx = 0;  // circular queue idx for round-robin selection
+
+ public:
+  explicit RoundRobinArbitrationPolicy(size_t fu_num) : fu_num(fu_num), fu_idx(fu_num - 1) {}
+  void prepare_picker_order() override;
+  size_t picker_at(size_t i) override;
+};
+
+void RoundRobinArbitrationPolicy::prepare_picker_order() {
   fu_idx = (fu_idx + 1) % fu_num;
 }
 
-FunctionalUnitPicker& RoundRobinOldestFirstSelectLogic::picker_at(size_t i) {
-  size_t picker_idx = (fu_idx + i) % fu_num;
-  ASSERT(node->proc_id, picker_idx < connected_fu_pickers.size());
-  return connected_fu_pickers[picker_idx];
+size_t RoundRobinArbitrationPolicy::picker_at(size_t i) {
+  return (fu_idx + i) % fu_num;
 }
+
+/**************************************************************************************/
+/*
+ * RoundRobineOldestFirstSelectLogic combines OldestFirstSchedulePolicy and RoundRobinArbitrationPolicy
+ * to implement a traditional superscalar issue queue with round-robin fairness and oldest-first selection.
+ */
+
+class RoundRobineOldestFirstSelectLogic : public SelectLogic {
+ public:
+  explicit RoundRobineOldestFirstSelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
+      : SelectLogic(connected_fu_pickers, std::make_unique<OldestFirstSchedulePolicy>(),
+                    std::make_unique<RoundRobinArbitrationPolicy>(connected_fu_pickers.size())) {}
+};
 
 /**************************************************************************************/
 /*
@@ -380,8 +418,8 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
   }
   DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
 
-  // initialize select logic based on scheduling scheme
-  select_logic = std::make_unique<RoundRobinOldestFirstSelectLogic>(queue_id, connected_fu_pickers);
+  // initialize select logic from the scheduling and arbitration policies.
+  select_logic = std::make_unique<RoundRobineOldestFirstSelectLogic>(connected_fu_pickers);
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -191,6 +191,8 @@ class FunctionalUnitPicker {
   void pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy);
   void grant();
   bool is_compatible(Inst_Info* inst_info) const;
+
+  uns32 get_fu_id() const { return fu_id; }
 };
 
 /*
@@ -198,24 +200,20 @@ class FunctionalUnitPicker {
  * selection, it replaces the existing selection according to the
  * scheduling policy.
  */
-void FunctionalUnitPicker::pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy) {
-  ASSERT(node->proc_id, candidate != nullptr);
-  if (!is_compatible(candidate->op->inst_info)) {
-    return;
-  }
-
-  bool replace = (picked_entry == nullptr || sched_policy.compare(candidate, picked_entry));
+void FunctionalUnitPicker::pick(IssueQueueEntry*& request_entry, const SchedulePolicy& sched_policy) {
+  ASSERT(node->proc_id, request_entry != nullptr);
+  bool replace = (picked_entry == nullptr || sched_policy.compare(request_entry, picked_entry));
   if (!replace) {
     return;
   }
 
   // replace the current selection
   IssueQueueEntry* displaced_entry = picked_entry;
-  picked_entry = candidate;
+  picked_entry = request_entry;
 
   // forward the displaced request to later pickers
   if (!ISSUE_QUEUE_PARALLEL_PICK) {
-    candidate = displaced_entry;
+    request_entry = displaced_entry;
   }
 }
 
@@ -261,23 +259,27 @@ bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
 
 class SelectLogic {
  protected:
-  std::vector<FunctionalUnitPicker> connected_fu_pickers;
-  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;
-  std::unique_ptr<ArbitrationPolicy> arbitration_policy;
-  std::vector<size_t> picker_order;
+  const uns proc_id;
+  const uns16 queue_id;
 
-  // the ready list is un-sorted
-  IssueQueueEntry* ready_head = nullptr;
+  std::vector<FunctionalUnitPicker> connected_fu_pickers;
+  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;  // per-picker scheduling policies
+  std::unique_ptr<ArbitrationPolicy> arbitration_policy;        // picker traversal policy for the current cycle
+
+  std::vector<size_t> picker_order;       // picker traversal order generated each cycle
+  IssueQueueEntry* ready_head = nullptr;  // head of the unsorted ready request list
+  uns64 ready_op_types = 0;               // bitmask of ready op types in this cycle
 
  public:
-  SelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
-              std::vector<std::unique_ptr<SchedulePolicy>> sched_policies,
-              std::unique_ptr<ArbitrationPolicy> arbitration_policy)
-      : connected_fu_pickers(connected_fu_pickers),
+  explicit SelectLogic(uns proc_id, uns16 queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
+                       std::vector<std::unique_ptr<SchedulePolicy>> sched_policies,
+                       std::unique_ptr<ArbitrationPolicy> arbitration_policy)
+      : proc_id(proc_id),
+        queue_id(queue_id),
+        connected_fu_pickers(connected_fu_pickers),
         sched_policies(std::move(sched_policies)),
         arbitration_policy(std::move(arbitration_policy)),
         picker_order(this->connected_fu_pickers.size()) {}
-  virtual ~SelectLogic() = default;
 
   void select();
   void request(IssueQueueEntry* entry);
@@ -295,6 +297,7 @@ class SelectLogic {
 void SelectLogic::select() {
   const size_t fu_num = connected_fu_pickers.size();
   arbitration_policy->build_picker_order(picker_order);
+  ready_op_types = 0;
 
   for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
@@ -302,24 +305,53 @@ void SelectLogic::select() {
       continue;
     }
 
-    IssueQueueEntry* candidate = entry;
+    // track the ready op types for stat collection
+    ready_op_types |= get_fu_type(entry->op->inst_info->table_info.op_type, entry->op->inst_info->table_info.is_simd);
 
-    for (size_t i = 0; i < fu_num && candidate != nullptr; ++i) {
+    // the current request propagated through the serial picker chain
+    IssueQueueEntry* request_entry = entry;
+
+    for (size_t i = 0; i < fu_num; ++i) {
+      // traverse pickers in arbitration order
       size_t picker_idx = picker_order[i];
       FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
-      fu_picker.pick(candidate, *sched_policies[picker_idx]);
+
+      if (!fu_picker.is_compatible(request_entry->op->inst_info)) {
+        continue;
+      }
+      fu_picker.pick(request_entry, *sched_policies[picker_idx]);
+
+      // the request has been consumed
+      if (request_entry == nullptr) {
+        break;
+      }
     }
 
-    if (candidate != nullptr) {
-      Op* op = candidate->op;
+    // the entry is not picked or displaced
+    if (request_entry != nullptr) {
       STAT_EVENT(node->proc_id, RS_OP_READY_NOT_ISSUED_TOTAL);
-      STAT_EVENT(node->proc_id, RS_0_OP_READY_NOT_ISSUED + (op->queue_id < 8 ? op->queue_id : 8));
+      STAT_EVENT(node->proc_id, RS_0_OP_READY_NOT_ISSUED + (queue_id < 8 ? queue_id : 8));
     }
   }
 
   for (size_t i = 0; i < fu_num; ++i) {
+    // grant the pick after scanning the ready list
     FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_order[i]];
     fu_picker.grant();
+
+    // track FU idle stats after scheduling
+    uns32 fu_id = fu_picker.get_fu_id();
+    if (node->sd.ops[fu_id] != NULL)
+      continue;
+
+    Func_Unit* fu = &exec->fus[fu_id];
+    if (fu->avail_cycle > cycle_count || fu->held_by_mem)
+      continue;
+
+    if ((ready_op_types & fu->type) == 0) {
+      STAT_EVENT(node->proc_id, FU_IDLE_NO_READY_OPS_TOTAL);
+      STAT_EVENT(node->proc_id, FU_0_IDLE_NO_READY_OPS + (fu_id < 32 ? fu_id : 32));
+    }
   }
 }
 
@@ -385,15 +417,26 @@ void RoundRobinArbitrationPolicy::build_picker_order(std::vector<size_t>& picker
 
 /**************************************************************************************/
 /* Factory */
+// TODO: abstract factory
 
-static std::unique_ptr<SchedulePolicy> make_schedule_policy(const FunctionalUnitPicker& fu_picker) {
-  (void)fu_picker;
-  return std::make_unique<OldestFirstSchedulePolicy>();
-}
+class IssueQueuePolicyFactory {
+ public:
+  std::vector<std::unique_ptr<SchedulePolicy>> make_schedule_policies(
+      const std::vector<FunctionalUnitPicker>& fu_pickers) {
+    std::vector<std::unique_ptr<SchedulePolicy>> policies;
+    policies.reserve(fu_pickers.size());
 
-static std::unique_ptr<ArbitrationPolicy> make_arbitration_policy(size_t fu_num) {
-  return std::make_unique<RoundRobinArbitrationPolicy>(fu_num);
-}
+    for (size_t i = 0; i < fu_pickers.size(); i++) {
+      policies.emplace_back(std::make_unique<OldestFirstSchedulePolicy>());
+    }
+
+    return policies;
+  }
+
+  std::unique_ptr<ArbitrationPolicy> make_arbitration_policy(size_t fu_num) {
+    return std::make_unique<RoundRobinArbitrationPolicy>(fu_num);
+  }
+};
 
 /**************************************************************************************/
 /*
@@ -415,7 +458,6 @@ class IssueQueue {
                       const std::vector<FunctionalUnitPicker>& connected_fu_pickers);
   uns16 allocate_entry(Op* op);
   void free_entry(uns16 entry_id);
-
   size_t available_entries() const { return free_list.size(); }
   const std::vector<IssueQueueEntry>& get_entries() const { return entries; }
 
@@ -439,13 +481,10 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
   DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
 
   // initialize select logic from the scheduling and arbitration policies.
-  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;
-  sched_policies.reserve(connected_fu_pickers.size());
-  for (const FunctionalUnitPicker& fu_picker : connected_fu_pickers) {
-    sched_policies.emplace_back(make_schedule_policy(fu_picker));
-  }
-  select_logic = std::make_unique<SelectLogic>(connected_fu_pickers, std::move(sched_policies),
-                                               make_arbitration_policy(connected_fu_pickers.size()));
+  IssueQueuePolicyFactory factory;
+  select_logic = std::make_unique<SelectLogic>(proc_id, queue_id, connected_fu_pickers,
+                                               factory.make_schedule_policies(connected_fu_pickers),
+                                               factory.make_arbitration_policy(connected_fu_pickers.size()));
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {
@@ -538,7 +577,6 @@ class IssueQueues {
   std::vector<uns64> fu_types;
 
   void update_mem_block();
-  void track_idle_stats();
   uns16 find_emptiest_queue(Op* op);
 
  public:
@@ -676,9 +714,6 @@ void IssueQueues::schedule() {
   for (IssueQueue& queue : issue_queues) {
     queue.schedule();
   }
-
-  // track FU idle stats after scheduling
-  track_idle_stats();
 }
 
 void IssueQueues::recover() {
@@ -722,26 +757,6 @@ void IssueQueues::update_mem_block() {
 
   INC_STAT_EVENT(node->proc_id, CORE_MEM_BLOCKED, node->mem_blocked);
   node->mem_block_length += node->mem_blocked;
-}
-
-void IssueQueues::track_idle_stats() {
-  // Iterate over FUs and check if FU can handle any ready op types from its connected RS
-  for (uns32 fu_id = 0; fu_id < NUM_FUS; ++fu_id) {
-    if (node->sd.ops[fu_id] != NULL)
-      continue;
-
-    Func_Unit* fu = &exec->fus[fu_id];
-    if (fu->avail_cycle > cycle_count || fu->held_by_mem)
-      continue;
-
-    uns16 queue_id = fu_map[fu_id];
-    ASSERT(0, queue_id != MAX_UNS16);
-
-    if ((fu_types[queue_id] & fu->type) == 0) {
-      STAT_EVENT(node->proc_id, FU_IDLE_NO_READY_OPS_TOTAL);
-      STAT_EVENT(node->proc_id, FU_0_IDLE_NO_READY_OPS + (fu_id < 32 ? fu_id : 32));
-    }
-  }
 }
 
 uns16 IssueQueues::find_emptiest_queue(Op* op) {

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -112,21 +112,10 @@ struct FunctionalUnitPicker {
   Flag check_op_ready(Op* op) const;
 
  public:
-  enum class PickStatus {
-    PICKED,
-    CANCELLED,
-    EXHAUSTED
-  };
-
-  struct PickResult {
-    PickStatus status;
-    IssueQueueEntry* entry;
-  };
-
   explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
       : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
 
-  FunctionalUnitPicker::PickResult pick_next(const std::unordered_set<Counter>& cancelled_mask);
+  IssueQueueEntry* pick_next(const std::unordered_set<Counter>& picked_mask);
   void grant_op(IssueQueueEntry* entry);
 
   bool is_compatible(Inst_Info* inst_info) const {
@@ -137,7 +126,7 @@ struct FunctionalUnitPicker {
   void init_ready_iter() { ready_iter = ready_list.begin(); }
 };
 
-FunctionalUnitPicker::PickResult FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& cancelled_mask) {
+IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& picked_mask) {
   while (ready_iter != ready_list.end()) {
     IssueQueueEntry* entry = ready_iter->second;
     Op* op = entry->op;
@@ -149,8 +138,8 @@ FunctionalUnitPicker::PickResult FunctionalUnitPicker::pick_next(const std::unor
        * This picker is unaware of current-round selections and loses arbitration.
        * The selection is cancelled and deferred to the next round.
        */
-      if (cancelled_mask.count(op->op_num)) {
-        return {PickStatus::CANCELLED, nullptr};
+      if (picked_mask.count(entry->entry_id)) {
+        return nullptr;
       }
 
       continue;
@@ -162,10 +151,10 @@ FunctionalUnitPicker::PickResult FunctionalUnitPicker::pick_next(const std::unor
     }
 
     ASSERT(proc_id, node->sd.ops[fu_id] == nullptr && is_compatible(op->inst_info));
-    return {PickStatus::PICKED, entry};
+    return entry;
   }
 
-  return {PickStatus::EXHAUSTED, nullptr};
+  return nullptr;
 }
 
 void FunctionalUnitPicker::grant_op(IssueQueueEntry* entry) {
@@ -274,40 +263,22 @@ void SelectLogic::select() {
     fu_picker.init_ready_iter();
   }
 
-  uint64_t active_mask = ((1ULL << fu_num) - 1);
-  std::unordered_set<Counter> cancelled_mask;
+  std::unordered_set<Counter> picked_mask;
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
+    IssueQueueEntry* entry = fu_picker.pick_next(picked_mask);
 
-  while (active_mask) {
-    cancelled_mask.clear();
-
-    for (size_t i = 0; i < fu_num; ++i) {
-      // skip the picker if it has picked an op or does not have any ready op to pick
-      if (!(active_mask & (1ULL << i))) {
-        continue;
-      }
-
-      FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
-      auto ret = fu_picker.pick_next(cancelled_mask);
-
-      // mark the picker inactive if the iterator reaches the end of the ready list
-      if (ret.status == FunctionalUnitPicker::PickStatus::EXHAUSTED) {
-        active_mask &= ~(1ULL << i);
-        continue;
-      }
-
-      // do the picking in the next round if it is cancelled due to a conflict in the same round
-      if (ret.status == FunctionalUnitPicker::PickStatus::CANCELLED) {
-        continue;
-      }
-
-      // mark the current pickas the winner to cancel competing picks for the same op in this round
-      if (ISSUE_QUEUE_PARALLEL_PICK) {
-        cancelled_mask.insert(ret.entry->op->op_num);
-      }
-
-      fu_picker.grant_op(ret.entry);
-      active_mask &= ~(1ULL << i);
+    // do the picking in the next round if it is cancelled due to a conflict in the same round
+    if (entry == nullptr) {
+      continue;
     }
+
+    // mark the current pickas the winner to cancel competing picks for the same op in this round
+    if (ISSUE_QUEUE_PARALLEL_PICK) {
+      picked_mask.insert(entry->entry_id);
+    }
+
+    fu_picker.grant_op(entry);
   }
 }
 
@@ -364,19 +335,6 @@ size_t RoundRobinArbitrationPolicy::picker_at(size_t i) {
 
 /**************************************************************************************/
 /*
- * RoundRobineOldestFirstSelectLogic combines OldestFirstSchedulePolicy and RoundRobinArbitrationPolicy
- * to implement a traditional superscalar issue queue with round-robin fairness and oldest-first selection.
- */
-
-class RoundRobineOldestFirstSelectLogic : public SelectLogic {
- public:
-  explicit RoundRobineOldestFirstSelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
-      : SelectLogic(connected_fu_pickers, std::make_unique<OldestFirstSchedulePolicy>(),
-                    std::make_unique<RoundRobinArbitrationPolicy>(connected_fu_pickers.size())) {}
-};
-
-/**************************************************************************************/
-/*
  * The issue queue is organized as a random queue, where instructions are dispatched into free entries
  * without any particular ordering.
  */
@@ -419,7 +377,9 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
   DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
 
   // initialize select logic from the scheduling and arbitration policies.
-  select_logic = std::make_unique<RoundRobineOldestFirstSelectLogic>(connected_fu_pickers);
+  select_logic =
+      std::make_unique<SelectLogic>(connected_fu_pickers, std::make_unique<OldestFirstSchedulePolicy>(),
+                                    std::make_unique<RoundRobinArbitrationPolicy>(connected_fu_pickers.size()));
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -107,6 +107,7 @@ struct IssueQueueEntry {
   const uns16 entry_id;
 
   Op* op = nullptr;
+  uns64 op_fu_type = 0;
   ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
   IssueQueueEntry* next_ready = nullptr;
 
@@ -117,11 +118,13 @@ struct IssueQueueEntry {
 
 void IssueQueueEntry::clear() {
   op = nullptr;
+  op_fu_type = 0;
   ASSERT(node->proc_id, next_ready == nullptr);
 }
 
 void IssueQueueEntry::fill(Op* op) {
   this->op = op;
+  op_fu_type = get_fu_type(op->inst_info->table_info.op_type, op->inst_info->table_info.is_simd);
 }
 
 /**************************************************************************************/
@@ -190,7 +193,7 @@ class FunctionalUnitPicker {
 
   void pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy);
   void grant();
-  bool is_compatible(Inst_Info* inst_info) const;
+  bool is_compatible(uns64 op_fu_type) const;
 
   uns32 get_fu_id() const { return fu_id; }
 };
@@ -245,8 +248,8 @@ void FunctionalUnitPicker::grant() {
   picked_entry = nullptr;
 }
 
-bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
-  return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
+bool FunctionalUnitPicker::is_compatible(uns64 op_fu_type) const {
+  return op_fu_type & fu_type;
 }
 
 /**************************************************************************************/
@@ -306,7 +309,7 @@ void SelectLogic::select() {
     }
 
     // track the ready op types for stat collection
-    ready_op_types |= get_fu_type(entry->op->inst_info->table_info.op_type, entry->op->inst_info->table_info.is_simd);
+    ready_op_types |= entry->op_fu_type;
 
     // the current request propagated through the serial picker chain
     IssueQueueEntry* request_entry = entry;
@@ -316,7 +319,7 @@ void SelectLogic::select() {
       size_t picker_idx = picker_order[i];
       FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
 
-      if (!fu_picker.is_compatible(request_entry->op->inst_info)) {
+      if (!fu_picker.is_compatible(request_entry->op_fu_type)) {
         continue;
       }
       fu_picker.pick(request_entry, *sched_policies[picker_idx]);

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -265,7 +265,7 @@ bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
 class SelectLogic {
  protected:
   std::vector<FunctionalUnitPicker> connected_fu_pickers;
-  std::unique_ptr<SchedulePolicy> sched_policy;
+  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;
   std::unique_ptr<ArbitrationPolicy> arbitration_policy;
 
   // the ready list is un-sorted
@@ -273,9 +273,10 @@ class SelectLogic {
 
  public:
   SelectLogic(const std::vector<FunctionalUnitPicker>& connected_fu_pickers,
-              std::unique_ptr<SchedulePolicy> sched_policy, std::unique_ptr<ArbitrationPolicy> arbitration_policy)
+              std::vector<std::unique_ptr<SchedulePolicy>> sched_policies,
+              std::unique_ptr<ArbitrationPolicy> arbitration_policy)
       : connected_fu_pickers(connected_fu_pickers),
-        sched_policy(std::move(sched_policy)),
+        sched_policies(std::move(sched_policies)),
         arbitration_policy(std::move(arbitration_policy)) {}
   virtual ~SelectLogic() = default;
 
@@ -305,8 +306,15 @@ void SelectLogic::select() {
     IssueQueueEntry* candidate = entry;
 
     for (size_t i = 0; i < fu_num && candidate != nullptr; ++i) {
-      FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
-      fu_picker.pick(candidate, *sched_policy);
+      size_t picker_idx = arbitration_policy->picker_at(i);
+      FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
+      fu_picker.pick(candidate, *sched_policies[picker_idx]);
+    }
+
+    if (candidate != nullptr) {
+      Op* op = candidate->op;
+      STAT_EVENT(node->proc_id, RS_OP_READY_NOT_ISSUED_TOTAL);
+      STAT_EVENT(node->proc_id, RS_0_OP_READY_NOT_ISSUED + (op->queue_id < 8 ? op->queue_id : 8));
     }
   }
 
@@ -378,6 +386,17 @@ size_t RoundRobinArbitrationPolicy::picker_at(size_t i) const {
 }
 
 /**************************************************************************************/
+/* Factory */
+
+static std::unique_ptr<SchedulePolicy> make_schedule_policy(const FunctionalUnitPicker& fu_picker) {
+  return std::make_unique<OldestFirstSchedulePolicy>();
+}
+
+static std::unique_ptr<ArbitrationPolicy> make_arbitration_policy(size_t fu_num) {
+  return std::make_unique<RoundRobinArbitrationPolicy>(fu_num);
+}
+
+/**************************************************************************************/
 /*
  * The issue queue is organized as a random queue, where instructions are dispatched into free entries
  * without any particular ordering.
@@ -421,9 +440,13 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
   DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
 
   // initialize select logic from the scheduling and arbitration policies.
-  select_logic =
-      std::make_unique<SelectLogic>(connected_fu_pickers, std::make_unique<OldestFirstSchedulePolicy>(),
-                                    std::make_unique<RoundRobinArbitrationPolicy>(connected_fu_pickers.size()));
+  std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;
+  sched_policies.reserve(connected_fu_pickers.size());
+  for (const FunctionalUnitPicker& fu_picker : connected_fu_pickers) {
+    sched_policies.emplace_back(make_schedule_policy(fu_picker));
+  }
+  select_logic = std::make_unique<SelectLogic>(connected_fu_pickers, std::move(sched_policies),
+                                               make_arbitration_policy(connected_fu_pickers.size()));
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -72,128 +72,9 @@ enum ISSUE_QUEUE_ENTRY_STATE {
 };
 
 /**************************************************************************************/
-/* Structures */
+/* Static methods */
 
-struct IssueQueueEntry {
-  const uns16 queue_id;
-  const uns16 entry_id;
-
-  Op* op = nullptr;
-  ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
-  IssueQueueEntry* next_ready = nullptr;
-
-  explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
-  void clear();
-  void fill(Op* op);
-};
-
-void IssueQueueEntry::clear() {
-  op = nullptr;
-}
-
-void IssueQueueEntry::fill(Op* op) {
-  this->op = op;
-}
-
-/**************************************************************************************/
-/* Virtual Interface */
-
-// SchedulePolicy is responsible for deciding the priority of picking
-class SchedulePolicy {
- public:
-  virtual ~SchedulePolicy() = default;
-
-  // Return if the lhs entry is the preference
-  virtual bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const = 0;
-};
-
-// ArbitrationPolicy is responsible for determining the picker order
-class ArbitrationPolicy {
- public:
-  virtual ~ArbitrationPolicy() = default;
-
-  // Prepare the picker order for the current selection cycle
-  virtual void prepare_picker_order() = 0;
-
-  // Get the picker index at the given index in the current order
-  virtual size_t picker_at(size_t i) const = 0;
-};
-
-/**************************************************************************************/
-
-struct FunctionalUnitPicker {
- private:
-  const uns proc_id;
-  const uns16 queue_id;
-  const uns32 fu_id;
-  const uns64 fu_type;
-
-  Flag check_op_ready(Op* op) const;
-
- public:
-  explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
-      : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
-
-  IssueQueueEntry* pick(IssueQueueEntry* ready_head, const std::unordered_set<uns16>& picked_mask,
-                        const SchedulePolicy& sched_policy);
-  void grant(IssueQueueEntry* entry);
-  bool is_compatible(Inst_Info* inst_info) const;
-};
-
-IssueQueueEntry* FunctionalUnitPicker::pick(IssueQueueEntry* ready_head, const std::unordered_set<uns16>& picked_mask,
-                                            const SchedulePolicy& sched_policy) {
-  IssueQueueEntry* ret = nullptr;
-  for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
-    if (entry->state == ISSUE_QUEUE_ENTRY_STATE_PICKED) {
-      continue;
-    }
-
-    if (!is_compatible(entry->op->inst_info)) {
-      continue;
-    }
-
-    // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
-    if (!check_op_ready(entry->op)) {
-      continue;
-    }
-
-    ASSERT(proc_id, node->sd.ops[fu_id] == nullptr);
-    if (ret == nullptr || sched_policy.compare(entry, ret)) {
-      ret = entry;
-    }
-  }
-
-  /*
-   * Conflict with another picker in the same round (parallel selection).
-   * This picker is unaware of current-round selections and loses arbitration.
-   * The selection is cancelled and deferred to the next round.
-   */
-  if (ret != nullptr && picked_mask.count(ret->entry_id)) {
-    return nullptr;
-  }
-
-  return ret;
-}
-
-void FunctionalUnitPicker::grant(IssueQueueEntry* entry) {
-  Op* op = entry->op;
-  ASSERT(proc_id, op != nullptr);
-  ASSERT(proc_id, fu_id < (uns32)node->sd.max_op_count && node->sd.ops[fu_id] == nullptr);
-  ASSERT(proc_id, node->sd.op_count < node->sd.max_op_count);
-
-  op->fu_num = fu_id;
-  node->sd.ops[op->fu_num] = op;
-  node->last_scheduled_opnum = op->op_num;
-  node->sd.op_count += 1;
-
-  entry->state = ISSUE_QUEUE_ENTRY_STATE_PICKED;
-}
-
-bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
-  return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
-}
-
-Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
+static inline Flag issue_queue_check_op_ready(Op* op) {
   ASSERT(node->proc_id, op != nullptr);
 
   // if the op is waiting for memory, check if it is still blocked by memory. If not, it becomes ready
@@ -219,9 +100,166 @@ Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
 }
 
 /**************************************************************************************/
+/* Structures */
+
+struct IssueQueueEntry {
+  const uns16 queue_id;
+  const uns16 entry_id;
+
+  Op* op = nullptr;
+  ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
+  IssueQueueEntry* next_ready = nullptr;
+
+  explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
+  void clear();
+  void fill(Op* op);
+};
+
+void IssueQueueEntry::clear() {
+  op = nullptr;
+  ASSERT(node->proc_id, next_ready == nullptr);
+}
+
+void IssueQueueEntry::fill(Op* op) {
+  this->op = op;
+}
+
+/**************************************************************************************/
+/* Virtual Interface */
+
 /*
- * The select logic is responsible for picking ready ops from the wakeup logic in the issue queue.
- * It is composed of a SchedulePolicy (in what order of ready lists) and an ArbitrationPolicy (in what order to pick).
+ * SchedulePolicy defines the relative priority between ready ops during selection. When
+ * multiple ops compete for the same picker, the policy determines which op is preferred.
+ *
+ * Typical scheduling policies include oldest-first, criticality-based, and dependency-aware
+ * prioritization.
+ */
+class SchedulePolicy {
+ public:
+  virtual ~SchedulePolicy() = default;
+
+  // Return if the lhs entry is the preference
+  virtual bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const = 0;
+};
+
+/*
+ * ArbitrationPolicy determines the picker traversal order, where pickers earlier in the
+ * order have higher priority.
+ *
+ * In serial selection, requests for later pickers are derived from the selections made
+ * by earlier pickers.
+ *
+ * In parallel selection, earlier pickers win arbitration and cancel conflicting selections
+ * from later pickers.
+ */
+class ArbitrationPolicy {
+ public:
+  virtual ~ArbitrationPolicy() = default;
+
+  // Prepare the picker order for the current selection cycle
+  virtual void prepare_picker_order() = 0;
+
+  // Get the picker index at the given index in the current order
+  virtual size_t picker_at(size_t i) const = 0;
+};
+
+/**************************************************************************************/
+
+/*
+ * FunctionalUnitPicker selects a single op for a functional unit during the current
+ * scheduling cycle.
+ *
+ * Each picker tracks the currently selected entry and updates the selection according to
+ * the scheduling policy when competing ops are observed.
+ *
+ * In serial selection, a newly selected op may displace the current selection and forward
+ * the displaced request to later pickers.
+ *
+ * In parallel selection, selections are resolved during grant.
+ */
+class FunctionalUnitPicker {
+ private:
+  const uns proc_id;
+  const uns16 queue_id;
+  const uns32 fu_id;
+  const uns64 fu_type;
+
+  // current selection for this cycle
+  IssueQueueEntry* picked_entry = nullptr;
+
+ public:
+  explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
+      : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
+
+  void pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy);
+  void grant();
+  bool is_compatible(Inst_Info* inst_info) const;
+};
+
+/*
+ * If the incoming request has higher priority than the current
+ * selection, it replaces the existing selection according to the
+ * scheduling policy.
+ */
+void FunctionalUnitPicker::pick(IssueQueueEntry*& candidate, const SchedulePolicy& sched_policy) {
+  ASSERT(node->proc_id, candidate != nullptr);
+  if (!is_compatible(candidate->op->inst_info)) {
+    return;
+  }
+
+  bool replace = (picked_entry == nullptr || sched_policy.compare(candidate, picked_entry));
+  if (!replace) {
+    return;
+  }
+
+  // replace the current selection
+  IssueQueueEntry* displaced_entry = picked_entry;
+  picked_entry = candidate;
+
+  // forward the displaced request to later pickers
+  if (!ISSUE_QUEUE_PARALLEL_PICK) {
+    candidate = displaced_entry;
+  }
+}
+
+void FunctionalUnitPicker::grant() {
+  // no valid selection this cycle
+  if (picked_entry == nullptr) {
+    return;
+  }
+
+  ASSERT(proc_id, ISSUE_QUEUE_PARALLEL_PICK || picked_entry->state == ISSUE_QUEUE_ENTRY_STATE_READY);
+  // another picker has already granted this entry
+  if (picked_entry->state == ISSUE_QUEUE_ENTRY_STATE_PICKED) {
+    picked_entry = nullptr;
+    return;
+  }
+
+  Op* op = picked_entry->op;
+  ASSERT(proc_id, op != nullptr);
+  ASSERT(proc_id, fu_id < (uns32)node->sd.max_op_count);
+  op->fu_num = fu_id;
+
+  // issue the op into the stage data
+  ASSERT(proc_id, node->sd.ops[fu_id] == nullptr && node->sd.op_count < node->sd.max_op_count);
+  node->sd.ops[op->fu_num] = op;
+  node->last_scheduled_opnum = op->op_num;
+  node->sd.op_count += 1;
+
+  picked_entry->state = ISSUE_QUEUE_ENTRY_STATE_PICKED;
+  picked_entry = nullptr;
+}
+
+bool FunctionalUnitPicker::is_compatible(Inst_Info* inst_info) const {
+  return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
+}
+
+/**************************************************************************************/
+/*
+ * The select logic is responsible for choosing ready ops for issue.
+ *
+ * It combines a SchedulePolicy, which defines the relative priority between competing ops,
+ * and an ArbitrationPolicy, which determines the priority of pickers during selection.
  */
 
 class SelectLogic {
@@ -229,6 +267,8 @@ class SelectLogic {
   std::vector<FunctionalUnitPicker> connected_fu_pickers;
   std::unique_ptr<SchedulePolicy> sched_policy;
   std::unique_ptr<ArbitrationPolicy> arbitration_policy;
+
+  // the ready list is un-sorted
   IssueQueueEntry* ready_head = nullptr;
 
  public:
@@ -256,23 +296,23 @@ void SelectLogic::select() {
   const size_t fu_num = connected_fu_pickers.size();
   arbitration_policy->prepare_picker_order();
 
-  std::unordered_set<uns16> picked_mask;
-  for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
-    IssueQueueEntry* entry = fu_picker.pick(ready_head, picked_mask, *sched_policy);
-
-    // if the picking is cancelled due to a conflict in the same round or there is no compatible entry
-    if (entry == nullptr) {
+  for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
+    // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
+    if (entry->state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry->op)) {
       continue;
     }
 
-    // mark the current pick as the winner to cancel competing picks for the same op in this round
-    if (ISSUE_QUEUE_PARALLEL_PICK) {
-      picked_mask.insert(entry->entry_id);
-    }
+    IssueQueueEntry* candidate = entry;
 
-    // issue the op into the stage_data
-    fu_picker.grant(entry);
+    for (size_t i = 0; i < fu_num && candidate != nullptr; ++i) {
+      FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
+      fu_picker.pick(candidate, *sched_policy);
+    }
+  }
+
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
+    fu_picker.grant();
   }
 }
 
@@ -313,6 +353,7 @@ class OldestFirstSchedulePolicy : public SchedulePolicy {
 };
 
 bool OldestFirstSchedulePolicy::compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const {
+  ASSERT(node->proc_id, lhs != nullptr && rhs != nullptr);
   return lhs->op->op_num < rhs->op->op_num;
 }
 

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -218,47 +218,16 @@ class SelectLogic {
  public:
   virtual ~SelectLogic() = default;
 
+  void select();
   virtual void request(IssueQueueEntry* entry) = 0;
   virtual void release(IssueQueueEntry* entry) = 0;
-  virtual void select() = 0;
+
+ protected:
+  // helper methods for select logic to interact with the pickers
+  virtual void prepare_picker_order() = 0;
+  virtual FunctionalUnitPicker& picker_at(size_t i) = 0;
+  virtual size_t picker_count() const = 0;
 };
-
-class OldestFirstSelectLogic : public SelectLogic {
- private:
-  const uns queue_id;
-  const size_t fu_num;
-  std::vector<FunctionalUnitPicker> connected_fu_pickers;
-
-  int fu_idx = 0;                    // circular queue idx for round-robin selection
-  std::vector<size_t> picker_order;  // the order of pickers to check in the current selection round
-
- public:
-  OldestFirstSelectLogic(uns queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
-      : queue_id(queue_id), fu_num(connected_fu_pickers.size()), connected_fu_pickers(connected_fu_pickers) {}
-  void request(IssueQueueEntry* entry) override;
-  void release(IssueQueueEntry* entry) override;
-  void select() override;
-};
-
-void OldestFirstSelectLogic::request(IssueQueueEntry* entry) {
-  Op* op = entry->op;
-  op->in_rdy_list = TRUE;
-  for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    if (fu_picker.is_compatible(op->inst_info)) {
-      fu_picker.add_ready_entry(op->op_num, entry);
-    }
-  }
-}
-
-void OldestFirstSelectLogic::release(IssueQueueEntry* entry) {
-  Op* op = entry->op;
-  op->in_rdy_list = FALSE;
-  for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
-    fu_picker.remove_ready_entry(op->op_num);
-  }
-}
 
 /*
  * Serial selection is described in "Quantifying the complexity of superscalar processors", 1996.
@@ -269,17 +238,14 @@ void OldestFirstSelectLogic::release(IssueQueueEntry* entry) {
  * An arbitrator is then used to resolve conflicts when multiple functional units select the same op.
  */
 
-void OldestFirstSelectLogic::select() {
-  // determine the order of pickers to check in this round (round-robin across pickers to achieve fairness)
-  picker_order.resize(fu_num);
-  for (size_t i = 0; i < fu_num; ++i) {
-    picker_order[i] = (fu_idx + i) % fu_num;
-  }
-  fu_idx = (fu_idx + 1) % fu_num;
+void SelectLogic::select() {
+  const size_t fu_num = picker_count();
+  prepare_picker_order();
 
-  // reset the ready iter for each picker to start from the oldest ready op
+  // reset the ready iter for each picker to start from the head of the ready list
   for (size_t i = 0; i < fu_num; ++i) {
-    connected_fu_pickers[i].init_ready_iter();
+    FunctionalUnitPicker& fu_picker = picker_at(i);
+    fu_picker.init_ready_iter();
   }
 
   uint64_t active_mask = ((1ULL << fu_num) - 1);
@@ -288,31 +254,87 @@ void OldestFirstSelectLogic::select() {
   while (active_mask) {
     cancelled_mask.clear();
 
-    for (size_t picker_idx : picker_order) {
-      if (!(active_mask & (1ULL << picker_idx))) {
+    for (size_t i = 0; i < fu_num; ++i) {
+      // skip the picker if it has picked an op or does not have any ready op to pick
+      if (!(active_mask & (1ULL << i))) {
         continue;
       }
 
-      FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
+      FunctionalUnitPicker& fu_picker = picker_at(i);
       auto ret = fu_picker.pick_next(cancelled_mask);
 
+      // mark the picker inactive if the iterator reaches the end of the ready list
       if (ret.status == FunctionalUnitPicker::PickStatus::EXHAUSTED) {
-        active_mask &= ~(1ULL << picker_idx);
+        active_mask &= ~(1ULL << i);
         continue;
       }
 
+      // do the picking in the next round if it is cancelled due to a conflict in the same round
       if (ret.status == FunctionalUnitPicker::PickStatus::CANCELLED) {
         continue;
       }
 
+      // mark the current pickas the winner to cancel competing picks for the same op in this round
       if (ISSUE_QUEUE_PARALLEL_PICK) {
         cancelled_mask.insert(ret.entry->op->op_num);
       }
 
       fu_picker.grant_op(ret.entry);
-      active_mask &= ~(1ULL << picker_idx);
+      active_mask &= ~(1ULL << i);
     }
   }
+}
+
+/**************************************************************************************/
+
+class RoundRobinOldestFirstSelectLogic : public SelectLogic {
+ private:
+  const uns queue_id;
+  const size_t fu_num;
+  int fu_idx = 0;  // circular queue idx for round-robin selection
+  std::vector<FunctionalUnitPicker> connected_fu_pickers;
+
+ public:
+  RoundRobinOldestFirstSelectLogic(uns queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
+      : queue_id(queue_id),
+        fu_num(connected_fu_pickers.size()),
+        fu_idx(fu_num - 1),
+        connected_fu_pickers(connected_fu_pickers) {}
+  void request(IssueQueueEntry* entry) override;
+  void release(IssueQueueEntry* entry) override;
+
+ protected:
+  void prepare_picker_order() override;
+  FunctionalUnitPicker& picker_at(size_t i) override;
+  size_t picker_count() const override { return fu_num; }
+};
+
+// oldest-first policy keeps the ready list of each picker sorted by op age
+void RoundRobinOldestFirstSelectLogic::request(IssueQueueEntry* entry) {
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
+    if (fu_picker.is_compatible(entry->op->inst_info)) {
+      fu_picker.add_ready_entry(entry->op->op_num, entry);
+    }
+  }
+}
+
+void RoundRobinOldestFirstSelectLogic::release(IssueQueueEntry* entry) {
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
+    fu_picker.remove_ready_entry(entry->op->op_num);
+  }
+}
+
+// round-robin mechanism is used to ensure fairness
+void RoundRobinOldestFirstSelectLogic::prepare_picker_order() {
+  fu_idx = (fu_idx + 1) % fu_num;
+}
+
+FunctionalUnitPicker& RoundRobinOldestFirstSelectLogic::picker_at(size_t i) {
+  size_t picker_idx = (fu_idx + i) % fu_num;
+  ASSERT(node->proc_id, picker_idx < connected_fu_pickers.size());
+  return connected_fu_pickers[picker_idx];
 }
 
 /**************************************************************************************/
@@ -359,7 +381,7 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
   DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
 
   // initialize select logic based on scheduling scheme
-  select_logic = std::make_unique<OldestFirstSelectLogic>(queue_id, connected_fu_pickers);
+  select_logic = std::make_unique<RoundRobinOldestFirstSelectLogic>(queue_id, connected_fu_pickers);
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {
@@ -394,6 +416,7 @@ void IssueQueue::wakeup(uns16 entry_id) {
   Op* op = entry.op;
   ASSERT(proc_id, op != nullptr);
 
+  op->in_rdy_list = TRUE;
   entry.state = ISSUE_QUEUE_ENTRY_STATE_READY;
   select_logic->request(&entry);
 }
@@ -407,6 +430,7 @@ void IssueQueue::issued(uns16 entry_id) {
   ASSERT(proc_id, op != nullptr);
 
   STAT_EVENT(node->proc_id, OP_ISSUED);
+  op->in_rdy_list = FALSE;
   select_logic->release(&entry);
   free_entry(entry.entry_id);
 }
@@ -426,6 +450,7 @@ void IssueQueue::recover() {
       continue;
     }
 
+    op->in_rdy_list = FALSE;
     select_logic->release(&entry);
     free_entry(entry.entry_id);
   }

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -450,6 +450,10 @@ void IssueQueue::recover() {
       continue;
     }
 
+    if (!FLUSH_OP(op)) {
+      continue;
+    }
+
     op->in_rdy_list = FALSE;
     select_logic->release(&entry);
     free_entry(entry.entry_id);

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -112,23 +112,32 @@ struct FunctionalUnitPicker {
   Flag check_op_ready(Op* op) const;
 
  public:
+  enum class PickStatus {
+    PICKED,
+    CANCELLED,
+    EXHAUSTED
+  };
+
+  struct PickResult {
+    PickStatus status;
+    IssueQueueEntry* entry;
+  };
+
   explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
       : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
 
-  IssueQueueEntry* pick_next(const std::unordered_set<Counter>& cancelled_mask);
-  void issue_op_into_sd(IssueQueueEntry* entry);
+  FunctionalUnitPicker::PickResult pick_next(const std::unordered_set<Counter>& cancelled_mask);
+  void grant_op(IssueQueueEntry* entry);
 
   bool is_compatible(Inst_Info* inst_info) const {
     return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
   }
   void add_ready_entry(Counter key, IssueQueueEntry* entry) { ready_list[key] = entry; }
   void remove_ready_entry(Counter key) { ready_list.erase(key); }
-
   void init_ready_iter() { ready_iter = ready_list.begin(); }
-  bool has_ready_entry() const { return ready_iter != ready_list.end(); }
 };
 
-IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& cancelled_mask) {
+FunctionalUnitPicker::PickResult FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& cancelled_mask) {
   while (ready_iter != ready_list.end()) {
     IssueQueueEntry* entry = ready_iter->second;
     Op* op = entry->op;
@@ -141,7 +150,7 @@ IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counte
        * The selection is cancelled and deferred to the next round.
        */
       if (cancelled_mask.count(op->op_num)) {
-        break;
+        return {PickStatus::CANCELLED, nullptr};
       }
 
       continue;
@@ -153,13 +162,13 @@ IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counte
     }
 
     ASSERT(proc_id, node->sd.ops[fu_id] == nullptr && is_compatible(op->inst_info));
-    return entry;
+    return {PickStatus::PICKED, entry};
   }
 
-  return nullptr;
+  return {PickStatus::EXHAUSTED, nullptr};
 }
 
-void FunctionalUnitPicker::issue_op_into_sd(IssueQueueEntry* entry) {
+void FunctionalUnitPicker::grant_op(IssueQueueEntry* entry) {
   Op* op = entry->op;
   ASSERT(proc_id, op != nullptr);
   ASSERT(proc_id, fu_id < (uns32)node->sd.max_op_count && node->sd.ops[fu_id] == nullptr);
@@ -207,6 +216,8 @@ Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
 
 class SelectLogic {
  public:
+  virtual ~SelectLogic() = default;
+
   virtual void request(IssueQueueEntry* entry) = 0;
   virtual void release(IssueQueueEntry* entry) = 0;
   virtual void select() = 0;
@@ -283,19 +294,22 @@ void OldestFirstSelectLogic::select() {
       }
 
       FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
-      IssueQueueEntry* entry = fu_picker.pick_next(cancelled_mask);
-      if (entry == nullptr) {
-        if (!fu_picker.has_ready_entry()) {
-          active_mask &= ~(1ULL << picker_idx);
-        }
+      auto ret = fu_picker.pick_next(cancelled_mask);
+
+      if (ret.status == FunctionalUnitPicker::PickStatus::EXHAUSTED) {
+        active_mask &= ~(1ULL << picker_idx);
+        continue;
+      }
+
+      if (ret.status == FunctionalUnitPicker::PickStatus::CANCELLED) {
         continue;
       }
 
       if (ISSUE_QUEUE_PARALLEL_PICK) {
-        cancelled_mask.insert(entry->op->op_num);
+        cancelled_mask.insert(ret.entry->op->op_num);
       }
 
-      fu_picker.issue_op_into_sd(entry);
+      fu_picker.grant_op(ret.entry);
       active_mask &= ~(1ULL << picker_idx);
     }
   }
@@ -326,7 +340,7 @@ class IssueQueue {
   const std::vector<IssueQueueEntry>& get_entries() const { return entries; }
 
   void wakeup(uns16 entry_id);
-  void grant(uns16 entry_id);
+  void issued(uns16 entry_id);
   void reject(uns16 entry_id);
 
   void recover();
@@ -384,7 +398,7 @@ void IssueQueue::wakeup(uns16 entry_id) {
   select_logic->request(&entry);
 }
 
-void IssueQueue::grant(uns16 entry_id) {
+void IssueQueue::issued(uns16 entry_id) {
   ASSERT(proc_id, entry_id < entries.size());
   IssueQueueEntry& entry = entries[entry_id];
   ASSERT(proc_id, entry.state == ISSUE_QUEUE_ENTRY_STATE_PICKED);
@@ -442,7 +456,7 @@ class IssueQueues {
   void recover();
 
   void wakeup(Op* op);
-  void grant(Op* op);
+  void issued(Op* op);
   void reject(Op* op);
 };
 
@@ -588,12 +602,12 @@ void IssueQueues::wakeup(Op* op) {
   queue.wakeup(op->queue_entry_id);
 }
 
-void IssueQueues::grant(Op* op) {
+void IssueQueues::issued(Op* op) {
   uns16 queue_id = op->queue_id;
   ASSERT(proc_id, queue_id < issue_queues.size());
   IssueQueue& queue = issue_queues[queue_id];
   ASSERT(proc_id, op->queue_entry_id != MAX_UNS16);
-  queue.grant(op->queue_entry_id);
+  queue.issued(op->queue_entry_id);
 }
 
 void IssueQueues::reject(Op* op) {
@@ -684,9 +698,9 @@ void issue_queue_wakeup(Op* op) {
   issue_queues->wakeup(op);
 }
 
-void issue_queue_grant(Op* op) {
+void issue_queue_issued(Op* op) {
   // release the entries of ops that are scheduled
-  issue_queues->grant(op);
+  issue_queues->issued(op);
 }
 
 void issue_queue_reject(Op* op) {

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -49,6 +49,7 @@ extern "C" {
 }
 
 #include <deque>
+#include <list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -266,7 +267,8 @@ class SelectLogic {
   std::unique_ptr<ArbitrationPolicy> arbitration_policy;
 
   std::vector<size_t> picker_order;  // picker traversal order generated each cycle
-  uns64 ready_op_types = 0;          // bitmask of ready op types in this cycle
+  std::list<IssueQueueEntry*> ready_list;
+  uns64 ready_op_types = 0;  // bitmask of ready op types in this cycle
 
  public:
   explicit SelectLogic(uns proc_id, uns16 queue_id, std::vector<FunctionalUnitPicker> connected_fu_pickers,
@@ -277,7 +279,9 @@ class SelectLogic {
         arbitration_policy(std::move(arbitration_policy)),
         picker_order(this->connected_fu_pickers.size()) {}
 
-  void select(std::vector<IssueQueueEntry>& entries);
+  void select();
+  void request(IssueQueueEntry* entry);
+  void release(IssueQueueEntry* entry);
 };
 
 /*
@@ -288,22 +292,22 @@ class SelectLogic {
  * Parallel selection allows each functional unit to independently select a ready op in the same cycle.
  * An arbitrator is then used to resolve conflicts when multiple functional units select the same op.
  */
-void SelectLogic::select(std::vector<IssueQueueEntry>& entries) {
+void SelectLogic::select() {
   const size_t fu_num = connected_fu_pickers.size();
   arbitration_policy->build_picker_order(picker_order);
   ready_op_types = 0;
 
-  for (IssueQueueEntry& entry : entries) {
+  for (IssueQueueEntry* entry : ready_list) {
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
-    if (entry.state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry.op)) {
+    if (entry->state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry->op)) {
       continue;
     }
 
     // track the ready op types for stat collection
-    ready_op_types |= entry.op_fu_type;
+    ready_op_types |= entry->op_fu_type;
 
     // the current request propagated through the serial picker chain
-    IssueQueueEntry* request_entry = &entry;
+    IssueQueueEntry* request_entry = entry;
 
     for (size_t i = 0; i < fu_num; ++i) {
       // traverse pickers in arbitration order
@@ -347,6 +351,16 @@ void SelectLogic::select(std::vector<IssueQueueEntry>& entries) {
       STAT_EVENT(node->proc_id, FU_0_IDLE_NO_READY_OPS + (fu_id < 32 ? fu_id : 32));
     }
   }
+}
+
+void SelectLogic::request(IssueQueueEntry* entry) {
+  ASSERT(node->proc_id, entry != nullptr);
+  ready_list.push_front(entry);
+}
+
+void SelectLogic::release(IssueQueueEntry* entry) {
+  ASSERT(node->proc_id, entry != nullptr);
+  ready_list.remove(entry);
 }
 
 /**************************************************************************************/
@@ -439,8 +453,9 @@ IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size, std::vector<Func
 
   // initialize select logic from the scheduling and arbitration policies.
   IssueQueuePolicyFactory factory;
+  size_t fu_num = connected_fu_pickers.size();
   select_logic = std::make_unique<SelectLogic>(proc_id, queue_id, std::move(connected_fu_pickers),
-                                               factory.make_arbitration_policy(connected_fu_pickers.size()));
+                                               factory.make_arbitration_policy(fu_num));
 }
 
 uns16 IssueQueue::allocate_entry(Op* op) {
@@ -477,6 +492,7 @@ void IssueQueue::wakeup(uns16 entry_id) {
 
   op->in_rdy_list = TRUE;
   entry.state = ISSUE_QUEUE_ENTRY_STATE_READY;
+  select_logic->request(&entry);
 }
 
 void IssueQueue::issued(uns16 entry_id) {
@@ -489,6 +505,7 @@ void IssueQueue::issued(uns16 entry_id) {
 
   STAT_EVENT(node->proc_id, OP_ISSUED);
   op->in_rdy_list = FALSE;
+  select_logic->release(&entry);
   free_entry(entry.entry_id);
 }
 
@@ -512,12 +529,13 @@ void IssueQueue::recover() {
     }
 
     op->in_rdy_list = FALSE;
+    select_logic->release(&entry);
     free_entry(entry.entry_id);
   }
 }
 
 void IssueQueue::schedule() {
-  select_logic->select(entries);
+  select_logic->select();
 }
 
 /**************************************************************************************/

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -157,10 +157,7 @@ class ArbitrationPolicy {
   virtual ~ArbitrationPolicy() = default;
 
   // Prepare the picker order for the current selection cycle
-  virtual void prepare_picker_order() = 0;
-
-  // Get the picker index at the given index in the current order
-  virtual size_t picker_at(size_t i) const = 0;
+  virtual void build_picker_order(std::vector<size_t>& picker_order) = 0;
 };
 
 /**************************************************************************************/
@@ -267,6 +264,7 @@ class SelectLogic {
   std::vector<FunctionalUnitPicker> connected_fu_pickers;
   std::vector<std::unique_ptr<SchedulePolicy>> sched_policies;
   std::unique_ptr<ArbitrationPolicy> arbitration_policy;
+  std::vector<size_t> picker_order;
 
   // the ready list is un-sorted
   IssueQueueEntry* ready_head = nullptr;
@@ -277,7 +275,8 @@ class SelectLogic {
               std::unique_ptr<ArbitrationPolicy> arbitration_policy)
       : connected_fu_pickers(connected_fu_pickers),
         sched_policies(std::move(sched_policies)),
-        arbitration_policy(std::move(arbitration_policy)) {}
+        arbitration_policy(std::move(arbitration_policy)),
+        picker_order(this->connected_fu_pickers.size()) {}
   virtual ~SelectLogic() = default;
 
   void select();
@@ -295,7 +294,7 @@ class SelectLogic {
  */
 void SelectLogic::select() {
   const size_t fu_num = connected_fu_pickers.size();
-  arbitration_policy->prepare_picker_order();
+  arbitration_policy->build_picker_order(picker_order);
 
   for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->next_ready) {
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
@@ -306,7 +305,7 @@ void SelectLogic::select() {
     IssueQueueEntry* candidate = entry;
 
     for (size_t i = 0; i < fu_num && candidate != nullptr; ++i) {
-      size_t picker_idx = arbitration_policy->picker_at(i);
+      size_t picker_idx = picker_order[i];
       FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
       fu_picker.pick(candidate, *sched_policies[picker_idx]);
     }
@@ -319,7 +318,7 @@ void SelectLogic::select() {
   }
 
   for (size_t i = 0; i < fu_num; ++i) {
-    FunctionalUnitPicker& fu_picker = connected_fu_pickers[arbitration_policy->picker_at(i)];
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_order[i]];
     fu_picker.grant();
   }
 }
@@ -373,22 +372,22 @@ class RoundRobinArbitrationPolicy : public ArbitrationPolicy {
 
  public:
   explicit RoundRobinArbitrationPolicy(size_t fu_num) : fu_num(fu_num), fu_idx(fu_num - 1) {}
-  void prepare_picker_order() override;
-  size_t picker_at(size_t i) const override;
+  void build_picker_order(std::vector<size_t>& picker_order) override;
 };
 
-void RoundRobinArbitrationPolicy::prepare_picker_order() {
+void RoundRobinArbitrationPolicy::build_picker_order(std::vector<size_t>& picker_order) {
+  ASSERT(node->proc_id, picker_order.size() == fu_num);
   fu_idx = (fu_idx + 1) % fu_num;
-}
-
-size_t RoundRobinArbitrationPolicy::picker_at(size_t i) const {
-  return (fu_idx + i) % fu_num;
+  for (size_t i = 0; i < fu_num; ++i) {
+    picker_order[i] = (fu_idx + i) % fu_num;
+  }
 }
 
 /**************************************************************************************/
 /* Factory */
 
 static std::unique_ptr<SchedulePolicy> make_schedule_policy(const FunctionalUnitPicker& fu_picker) {
+  (void)fu_picker;
   return std::make_unique<OldestFirstSchedulePolicy>();
 }
 

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -1,0 +1,714 @@
+/*
+ * Copyright 2026 University of California Santa Cruz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/***************************************************************************************
+ * File         : issue_queue.cc
+ * Author       : Yinyuan Zhao, Litz Lab
+ * Date         : 4/2026
+ * Description  :
+ ***************************************************************************************/
+
+#include "issue_queue.h"
+
+extern "C" {
+#include "globals/assert.h"
+#include "globals/global_defs.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "debug/debug.param.h"
+#include "debug/debug_macros.h"
+#include "debug/debug_print.h"
+
+#include "bp/bp.h"
+#include "memory/memory.h"
+
+#include "exec_ports.h"
+#include "map_rename.h"
+#include "node_stage.h"
+}
+
+#include <deque>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+/**************************************************************************************/
+/* Macros */
+
+#define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_NODE_STAGE, ##args)
+
+/**************************************************************************************/
+/* Constexpr */
+
+enum ISSUE_QUEUE_ENTRY_STATE {
+  ISSUE_QUEUE_ENTRY_STATE_EMPTY,
+  ISSUE_QUEUE_ENTRY_STATE_ALLOCATED,
+  ISSUE_QUEUE_ENTRY_STATE_READY,
+  ISSUE_QUEUE_ENTRY_STATE_PICKED,
+  ISSUE_QUEUE_ENTRY_STATE_NUM
+};
+
+/**************************************************************************************/
+/* Structures */
+
+struct IssueQueueEntry {
+  const uns16 queue_id;
+  const uns16 entry_id;
+
+  Op* op = nullptr;
+  ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
+
+  explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
+  void clear();
+  void fill(Op* op);
+};
+
+void IssueQueueEntry::clear() {
+  op = nullptr;
+}
+
+void IssueQueueEntry::fill(Op* op) {
+  this->op = op;
+}
+
+/**************************************************************************************/
+
+struct FunctionalUnitPicker {
+ private:
+  const uns proc_id;
+  const uns16 queue_id;
+  const uns32 fu_id;
+  const uns64 fu_type;
+
+  using ReadyList = std::map<Counter, IssueQueueEntry*>;
+  using ReadyIter = ReadyList::iterator;
+  ReadyList ready_list;
+  ReadyIter ready_iter;
+
+  Flag check_op_ready(Op* op) const;
+
+ public:
+  explicit FunctionalUnitPicker(uns proc_id, uns16 queue_id, uns32 fu_id, uns64 fu_type)
+      : proc_id(proc_id), queue_id(queue_id), fu_id(fu_id), fu_type(fu_type) {}
+
+  IssueQueueEntry* pick_next(const std::unordered_set<Counter>& cancelled_mask);
+  void issue_op_into_sd(IssueQueueEntry* entry);
+
+  bool is_compatible(Inst_Info* inst_info) const {
+    return get_fu_type(inst_info->table_info.op_type, inst_info->table_info.is_simd) & fu_type;
+  }
+  void add_ready_entry(Counter key, IssueQueueEntry* entry) { ready_list[key] = entry; }
+  void remove_ready_entry(Counter key) { ready_list.erase(key); }
+
+  void init_ready_iter() { ready_iter = ready_list.begin(); }
+  bool has_ready_entry() const { return ready_iter != ready_list.end(); }
+};
+
+IssueQueueEntry* FunctionalUnitPicker::pick_next(const std::unordered_set<Counter>& cancelled_mask) {
+  while (ready_iter != ready_list.end()) {
+    IssueQueueEntry* entry = ready_iter->second;
+    Op* op = entry->op;
+    ++ready_iter;
+
+    if (entry->state == ISSUE_QUEUE_ENTRY_STATE_PICKED) {
+      /*
+       * Conflict with another picker in the same round (parallel selection).
+       * This picker is unaware of current-round selections and loses arbitration.
+       * The selection is cancelled and deferred to the next round.
+       */
+      if (cancelled_mask.count(op->op_num)) {
+        break;
+      }
+
+      continue;
+    }
+
+    // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
+    if (!check_op_ready(op)) {
+      continue;
+    }
+
+    ASSERT(proc_id, node->sd.ops[fu_id] == nullptr && is_compatible(op->inst_info));
+    return entry;
+  }
+
+  return nullptr;
+}
+
+void FunctionalUnitPicker::issue_op_into_sd(IssueQueueEntry* entry) {
+  Op* op = entry->op;
+  ASSERT(proc_id, op != nullptr);
+  ASSERT(proc_id, fu_id < (uns32)node->sd.max_op_count && node->sd.ops[fu_id] == nullptr);
+  ASSERT(proc_id, node->sd.op_count < node->sd.max_op_count);
+
+  op->fu_num = fu_id;
+  node->sd.ops[op->fu_num] = op;
+  node->last_scheduled_opnum = op->op_num;
+  node->sd.op_count += 1;
+
+  entry->state = ISSUE_QUEUE_ENTRY_STATE_PICKED;
+}
+
+Flag FunctionalUnitPicker::check_op_ready(Op* op) const {
+  ASSERT(node->proc_id, op != nullptr);
+
+  // if the op is waiting for memory, check if it is still blocked by memory. If not, it becomes ready
+  if (op->state == OS_WAIT_MEM) {
+    if (node->mem_blocked) {
+      return FALSE;
+    }
+    op->state = OS_READY;
+  }
+
+  if (op->state == OS_TENTATIVE || op->state == OS_WAIT_DCACHE) {
+    return FALSE;
+  }
+  ASSERT(node->proc_id, op->state == OS_IN_RS || op->state == OS_READY || op->state == OS_WAIT_FWD);
+
+  // if the op is waiting for forwarding, check if it can be forwarded in time to be ready in the next cycle
+  if (cycle_count < op->rdy_cycle - 1) {
+    return FALSE;
+  }
+  ASSERT(node->proc_id, op_sources_not_rdy_is_clear(op));
+
+  return TRUE;
+}
+
+/**************************************************************************************/
+/*
+ * The select logic is responsible for picking ready ops from the wakeup logic in the issue queue.
+ * Since the issue queue is organized in a non-ordered (random) manner, the select logic typically relies
+ * on an age matrix to track the relative age of entries.
+ */
+
+class SelectLogic {
+ public:
+  virtual void request(IssueQueueEntry* entry) = 0;
+  virtual void release(IssueQueueEntry* entry) = 0;
+  virtual void select() = 0;
+};
+
+class OldestFirstSelectLogic : public SelectLogic {
+ private:
+  const uns queue_id;
+  const size_t fu_num;
+  std::vector<FunctionalUnitPicker> connected_fu_pickers;
+
+  int fu_idx = 0;                    // circular queue idx for round-robin selection
+  std::vector<size_t> picker_order;  // the order of pickers to check in the current selection round
+
+ public:
+  OldestFirstSelectLogic(uns queue_id, const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
+      : queue_id(queue_id), fu_num(connected_fu_pickers.size()), connected_fu_pickers(connected_fu_pickers) {}
+  void request(IssueQueueEntry* entry) override;
+  void release(IssueQueueEntry* entry) override;
+  void select() override;
+};
+
+void OldestFirstSelectLogic::request(IssueQueueEntry* entry) {
+  Op* op = entry->op;
+  op->in_rdy_list = TRUE;
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
+    if (fu_picker.is_compatible(op->inst_info)) {
+      fu_picker.add_ready_entry(op->op_num, entry);
+    }
+  }
+}
+
+void OldestFirstSelectLogic::release(IssueQueueEntry* entry) {
+  Op* op = entry->op;
+  op->in_rdy_list = FALSE;
+  for (size_t i = 0; i < fu_num; ++i) {
+    FunctionalUnitPicker& fu_picker = connected_fu_pickers[i];
+    fu_picker.remove_ready_entry(op->op_num);
+  }
+}
+
+/*
+ * Serial selection is described in "Quantifying the complexity of superscalar processors", 1996.
+ * The select logic consists of multiple picking blocks arranged in series and each block receives
+ * request signals that are derived from the requests of the preceding block.
+ *
+ * Parallel selection allows each functional unit to independently select a ready op in the same cycle.
+ * An arbitrator is then used to resolve conflicts when multiple functional units select the same op.
+ */
+
+void OldestFirstSelectLogic::select() {
+  // determine the order of pickers to check in this round (round-robin across pickers to achieve fairness)
+  picker_order.resize(fu_num);
+  for (size_t i = 0; i < fu_num; ++i) {
+    picker_order[i] = (fu_idx + i) % fu_num;
+  }
+  fu_idx = (fu_idx + 1) % fu_num;
+
+  // reset the ready iter for each picker to start from the oldest ready op
+  for (size_t i = 0; i < fu_num; ++i) {
+    connected_fu_pickers[i].init_ready_iter();
+  }
+
+  uint64_t active_mask = ((1ULL << fu_num) - 1);
+  std::unordered_set<Counter> cancelled_mask;
+
+  while (active_mask) {
+    cancelled_mask.clear();
+
+    for (size_t picker_idx : picker_order) {
+      if (!(active_mask & (1ULL << picker_idx))) {
+        continue;
+      }
+
+      FunctionalUnitPicker& fu_picker = connected_fu_pickers[picker_idx];
+      IssueQueueEntry* entry = fu_picker.pick_next(cancelled_mask);
+      if (entry == nullptr) {
+        if (!fu_picker.has_ready_entry()) {
+          active_mask &= ~(1ULL << picker_idx);
+        }
+        continue;
+      }
+
+      if (ISSUE_QUEUE_PARALLEL_PICK) {
+        cancelled_mask.insert(entry->op->op_num);
+      }
+
+      fu_picker.issue_op_into_sd(entry);
+      active_mask &= ~(1ULL << picker_idx);
+    }
+  }
+}
+
+/**************************************************************************************/
+/*
+ * The issue queue is organized as a random queue, where instructions are dispatched into free entries
+ * without any particular ordering.
+ */
+
+class IssueQueue {
+ private:
+  const uns proc_id;
+  const uns16 queue_id;
+
+  std::vector<IssueQueueEntry> entries;
+  std::deque<uns16> free_list;
+  std::unique_ptr<SelectLogic> select_logic;
+
+ public:
+  explicit IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
+                      const std::vector<FunctionalUnitPicker>& connected_fu_pickers);
+  uns16 allocate_entry(Op* op);
+  void free_entry(uns16 entry_id);
+
+  size_t available_entries() const { return free_list.size(); }
+  const std::vector<IssueQueueEntry>& get_entries() const { return entries; }
+
+  void wakeup(uns16 entry_id);
+  void grant(uns16 entry_id);
+  void reject(uns16 entry_id);
+
+  void recover();
+  void schedule();
+};
+
+IssueQueue::IssueQueue(uns proc_id, uns16 queue_id, uns16 size,
+                       const std::vector<FunctionalUnitPicker>& connected_fu_pickers)
+    : proc_id(proc_id), queue_id(queue_id) {
+  // initialize entries and free list
+  entries.reserve(size);
+  for (uns16 i = 0; i < size; ++i) {
+    entries.emplace_back(queue_id, i);
+    free_list.push_back(i);
+  }
+  DEBUG(proc_id, "Initializing Issue Queue %d with size %d\n", queue_id, size);
+
+  // initialize select logic based on scheduling scheme
+  select_logic = std::make_unique<OldestFirstSelectLogic>(queue_id, connected_fu_pickers);
+}
+
+uns16 IssueQueue::allocate_entry(Op* op) {
+  // get an available entry from the free list
+  ASSERT(proc_id, !free_list.empty());
+  uns16 entry_id = free_list.front();
+  free_list.pop_front();
+
+  // fill the op info into the entry
+  IssueQueueEntry& entry = entries[entry_id];
+  ASSERT(proc_id, entry.state == ISSUE_QUEUE_ENTRY_STATE_EMPTY);
+  entry.fill(op);
+  entry.state = ISSUE_QUEUE_ENTRY_STATE_ALLOCATED;
+
+  return entry_id;
+}
+
+void IssueQueue::free_entry(uns16 entry_id) {
+  IssueQueueEntry& entry = entries[entry_id];
+  ASSERT(proc_id, entry.state != ISSUE_QUEUE_ENTRY_STATE_EMPTY);
+
+  entry.clear();
+  entry.state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
+  free_list.push_back(entry_id);
+}
+
+void IssueQueue::wakeup(uns16 entry_id) {
+  ASSERT(proc_id, entry_id < entries.size());
+  IssueQueueEntry& entry = entries[entry_id];
+  ASSERT(proc_id, entry.state == ISSUE_QUEUE_ENTRY_STATE_ALLOCATED);
+
+  Op* op = entry.op;
+  ASSERT(proc_id, op != nullptr);
+
+  entry.state = ISSUE_QUEUE_ENTRY_STATE_READY;
+  select_logic->request(&entry);
+}
+
+void IssueQueue::grant(uns16 entry_id) {
+  ASSERT(proc_id, entry_id < entries.size());
+  IssueQueueEntry& entry = entries[entry_id];
+  ASSERT(proc_id, entry.state == ISSUE_QUEUE_ENTRY_STATE_PICKED);
+
+  Op* op = entry.op;
+  ASSERT(proc_id, op != nullptr);
+
+  STAT_EVENT(node->proc_id, OP_ISSUED);
+  select_logic->release(&entry);
+  free_entry(entry.entry_id);
+}
+
+void IssueQueue::reject(uns16 entry_id) {
+  ASSERT(proc_id, entry_id < entries.size());
+  IssueQueueEntry& entry = entries[entry_id];
+  ASSERT(proc_id, entry.state == ISSUE_QUEUE_ENTRY_STATE_PICKED);
+
+  entry.state = ISSUE_QUEUE_ENTRY_STATE_READY;
+}
+
+void IssueQueue::recover() {
+  for (IssueQueueEntry& entry : entries) {
+    Op* op = entry.op;
+    if (op == nullptr || !op->off_path) {
+      continue;
+    }
+
+    select_logic->release(&entry);
+    free_entry(entry.entry_id);
+  }
+}
+
+void IssueQueue::schedule() {
+  select_logic->select();
+}
+
+/**************************************************************************************/
+
+class IssueQueues {
+ private:
+  const uns proc_id;
+  std::vector<IssueQueue> issue_queues;
+  std::vector<uns16> fu_map;
+  std::vector<uns64> fu_types;
+
+  void update_mem_block();
+  void track_idle_stats();
+  uns16 find_emptiest_queue(Op* op);
+
+ public:
+  explicit IssueQueues(uns proc_id);
+
+  void dispatch();
+  void schedule();
+  void recover();
+
+  void wakeup(Op* op);
+  void grant(Op* op);
+  void reject(Op* op);
+};
+
+IssueQueues::IssueQueues(uns proc_id) : proc_id(proc_id) {
+  auto split_tokens = [](const std::string& s) {
+    std::vector<std::string> tokens;
+    for (size_t pos = 0; pos < s.size();) {
+      size_t next = s.find(' ', pos);
+      tokens.emplace_back(s.substr(pos, next == std::string::npos ? s.size() - pos : next - pos));
+      if (next == std::string::npos)
+        break;
+      pos = next + 1;
+    }
+    return tokens;
+  };
+  auto parse_mask = [](const std::string& s) -> uns64 {
+    ASSERT(0, !s.empty());
+    switch (s.front()) {
+      case 'x':
+        return static_cast<uns64>(std::stoull(s.substr(1), nullptr, 16));
+      case 'b':
+        return static_cast<uns64>(std::stoull(s.substr(1), nullptr, 2));
+      default:
+        return static_cast<uns64>(std::stoull(s, nullptr, 10));
+    }
+  };
+
+  // initialize connection map from FUs to issue queues
+  std::vector<std::string> connection_tokens = split_tokens(RS_CONNECTIONS);
+  ASSERT(proc_id, connection_tokens.size() == NUM_RS);
+  fu_map.assign(NUM_FUS, MAX_UNS16);
+  for (size_t i = 0; i < NUM_RS; ++i) {
+    for (uns64 mask = parse_mask(connection_tokens[i]); mask; mask &= (mask - 1)) {
+      int idx = __builtin_ctzll(mask);
+      ASSERT(proc_id, idx < (int)NUM_FUS);
+      fu_map[idx] = i;
+    }
+  }
+
+  // initialize the connected FUs for each issue queue
+  std::vector<std::string> fu_tokens = split_tokens(FU_TYPES);
+  ASSERT(proc_id, fu_tokens.size() == NUM_FUS);
+  std::vector<std::vector<FunctionalUnitPicker>> fu_connection(NUM_RS);
+  fu_types.assign(NUM_RS, 0);
+  for (size_t i = 0; i < NUM_FUS; ++i) {
+    uns64 fu_type = parse_mask(fu_tokens[i]);
+    fu_connection[fu_map[i]].emplace_back(proc_id, fu_map[i], i, fu_type);
+    fu_types[fu_map[i]] |= fu_type;
+    DEBUG(proc_id, "FU %ld, queue: %d, type: 0x%llx\n", i, fu_map[i], fu_type);
+  }
+
+  // create issue queues based on configuration
+  issue_queues.reserve(NUM_RS);
+  const char* p = RS_SIZES;
+  for (uns16 i = 0; i < NUM_RS; ++i) {
+    char* end = nullptr;
+    uns64 size = strtoull(p, &end, 10);
+    issue_queues.emplace_back(proc_id, i, size, fu_connection[i]);
+    p = end;
+  }
+}
+
+/*
+ * Fill the scheduling window (RS) with oldest available ops.
+ * For each available op:
+ *  - Allocate it to its designated reservation station.
+ *  - If all source operands are ready, insert it into the ready list.
+ */
+void IssueQueues::dispatch() {
+  Op* op = NULL;
+  uns32 num_fill_rs = 0;
+
+  for (op = node->next_op_into_rs; op; op = op->next_node) {
+    ASSERT(proc_id, op->queue_id == MAX_UNS16 && op->queue_entry_id == MAX_UNS16);
+    uns16 queue_id = find_emptiest_queue(op);
+    if (queue_id == MAX_UNS16) {
+      break;
+    }
+
+    IssueQueue& queue = issue_queues[queue_id];
+    ASSERT(proc_id, queue.available_entries() > 0);
+    op->queue_id = queue_id;
+    op->queue_entry_id = queue.allocate_entry(op);
+    num_fill_rs++;
+
+    ASSERT(node->proc_id, op->state == OS_IN_ROB);
+    op->state = OS_IN_RS;
+
+    if (op_sources_not_rdy_is_clear(op)) {
+      queue.wakeup(op->queue_entry_id);
+      op->state = (cycle_count + 1 >= op->rdy_cycle ? OS_READY : OS_WAIT_FWD);
+    }
+
+    // maximum number of operations to fill into the RS per cycle (0 = unlimited)
+    if (RS_FILL_WIDTH && (num_fill_rs == RS_FILL_WIDTH)) {
+      op = op->next_node;
+      break;
+    }
+  }
+
+  // mark the next node to continue filling in the next cycle
+  node->next_op_into_rs = op;
+}
+
+/*
+ * Schedule ready ops (ops that are currently in the ready list).
+ *
+ * Input:  ready_list, containing all ops that are ready to issue from each of the RSs.
+ * Output: node->sd, containing ops thats being passed to the FUs.
+ *
+ * If a functional unit is available, it will accept the scheduled op,
+ * which is then removed from the ready list. If no FU is available, the
+ * op remains in the ready list to be considered in the next
+ * scheduling cycle.
+ */
+void IssueQueues::schedule() {
+  // the next stage is supposed to clear them out
+  ASSERT(node->proc_id, node->sd.op_count == 0);
+
+  // checks if any of the L1 MSHRs have become available
+  update_mem_block();
+
+  // for each issue queue, select ready ops to issue based on the scheduling scheme and FU availability
+  for (IssueQueue& queue : issue_queues) {
+    queue.schedule();
+  }
+
+  // track FU idle stats after scheduling
+  track_idle_stats();
+}
+
+void IssueQueues::recover() {
+  for (IssueQueue& queue : issue_queues) {
+    queue.recover();
+  }
+}
+
+void IssueQueues::wakeup(Op* op) {
+  uns16 queue_id = op->queue_id;
+  ASSERT(proc_id, queue_id < issue_queues.size());
+  IssueQueue& queue = issue_queues[queue_id];
+  ASSERT(proc_id, op->queue_entry_id != MAX_UNS16);
+  queue.wakeup(op->queue_entry_id);
+}
+
+void IssueQueues::grant(Op* op) {
+  uns16 queue_id = op->queue_id;
+  ASSERT(proc_id, queue_id < issue_queues.size());
+  IssueQueue& queue = issue_queues[queue_id];
+  ASSERT(proc_id, op->queue_entry_id != MAX_UNS16);
+  queue.grant(op->queue_entry_id);
+}
+
+void IssueQueues::reject(Op* op) {
+  uns16 queue_id = op->queue_id;
+  ASSERT(proc_id, queue_id < issue_queues.size());
+  IssueQueue& queue = issue_queues[queue_id];
+  ASSERT(proc_id, op->queue_entry_id != MAX_UNS16);
+  queue.reject(op->queue_entry_id);
+}
+
+// Memory is blocked when there are no more MSHRs in the L1 Q (i.e., there is no way to handle a D-Cache miss)
+void IssueQueues::update_mem_block() {
+  // if we are stalled due to lack of MSHRs to the L1, check to see if there is space now
+  if (node->mem_blocked && mem_can_allocate_req_buffer(node->proc_id, MRT_DFETCH, FALSE)) {
+    node->mem_blocked = FALSE;
+    STAT_EVENT(node->proc_id, MEM_BLOCK_LENGTH_0 + MIN2(node->mem_block_length, 5000) / 100);
+    node->mem_block_length = 0;
+  }
+
+  INC_STAT_EVENT(node->proc_id, CORE_MEM_BLOCKED, node->mem_blocked);
+  node->mem_block_length += node->mem_blocked;
+}
+
+void IssueQueues::track_idle_stats() {
+  // Iterate over FUs and check if FU can handle any ready op types from its connected RS
+  for (uns32 fu_id = 0; fu_id < NUM_FUS; ++fu_id) {
+    if (node->sd.ops[fu_id] != NULL)
+      continue;
+
+    Func_Unit* fu = &exec->fus[fu_id];
+    if (fu->avail_cycle > cycle_count || fu->held_by_mem)
+      continue;
+
+    uns16 queue_id = fu_map[fu_id];
+    ASSERT(0, queue_id != MAX_UNS16);
+
+    if ((fu_types[queue_id] & fu->type) == 0) {
+      STAT_EVENT(node->proc_id, FU_IDLE_NO_READY_OPS_TOTAL);
+      STAT_EVENT(node->proc_id, FU_0_IDLE_NO_READY_OPS + (fu_id < 32 ? fu_id : 32));
+    }
+  }
+}
+
+uns16 IssueQueues::find_emptiest_queue(Op* op) {
+  uns16 emptiest_queue_id = MAX_UNS16;
+  size_t emptiest_queue_entries = 0;
+
+  uns64 op_fu_type = get_fu_type(op->inst_info->table_info.op_type, op->inst_info->table_info.is_simd);
+  for (size_t queue_id = 0; queue_id < issue_queues.size(); ++queue_id) {
+    const IssueQueue& queue = issue_queues[queue_id];
+    uns64 queue_fu_types = fu_types[queue_id];
+    if (!(op_fu_type & queue_fu_types)) {
+      continue;
+    }
+
+    size_t empty_entries = queue.available_entries();
+    if (empty_entries == 0) {
+      continue;
+    }
+
+    if (emptiest_queue_entries < empty_entries) {
+      emptiest_queue_id = queue_id;
+      emptiest_queue_entries = empty_entries;
+    }
+  }
+
+  return emptiest_queue_id;
+}
+
+/**************************************************************************************/
+/* Global Values */
+
+static std::vector<IssueQueues> per_core_issue_queues;
+IssueQueues* issue_queues = nullptr;
+
+/**************************************************************************************/
+/* External Function */
+
+void issue_queue_update() {
+  // dispatch ops from the reorder buffer to the corresponding issue queues
+  issue_queues->dispatch();
+
+  // schedule ready ops in the issue queue to the functional units
+  issue_queues->schedule();
+}
+
+void issue_queue_wakeup(Op* op) {
+  issue_queues->wakeup(op);
+}
+
+void issue_queue_grant(Op* op) {
+  // release the entries of ops that are scheduled
+  issue_queues->grant(op);
+}
+
+void issue_queue_reject(Op* op) {
+  // update the entries of ops that are rejected during the execution stage
+  issue_queues->reject(op);
+}
+
+/**************************************************************************************/
+/* Vanilla API */
+
+void alloc_mem_issue_queue(uns num_cores) {
+  per_core_issue_queues.reserve(num_cores);
+  for (uns ii = 0; ii < num_cores; ii++) {
+    per_core_issue_queues.emplace_back(ii);
+  }
+}
+
+void set_issue_queue(uns8 proc_id) {
+  issue_queues = &per_core_issue_queues[proc_id];
+}
+
+void recover_issue_queue() {
+  ASSERT(node->proc_id, issue_queues != nullptr);
+  issue_queues->recover();
+}

--- a/src/issue_queue.h
+++ b/src/issue_queue.h
@@ -41,7 +41,7 @@ extern "C" {
 
 void issue_queue_update();
 void issue_queue_wakeup(Op* op);
-void issue_queue_grant(Op* op);
+void issue_queue_issued(Op* op);
 void issue_queue_reject(Op* op);
 
 // vanilla hps interface

--- a/src/issue_queue.h
+++ b/src/issue_queue.h
@@ -1,4 +1,5 @@
-/* Copyright 2020 HPS/SAFARI Research Groups
+/*
+ * Copyright 2026 University of California Santa Cruz
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,57 +21,36 @@
  */
 
 /***************************************************************************************
- * File         : globals/global_defs.h
- * Author       : HPS Research Group
- * Date         : 10/15/1997
- * Description  : Global defines that are intended to be included in every
- *source file.
+ * File         : issue_queue.h
+ * Author       : Yinyuan Zhao, Litz Lab
+ * Date         : 4/2026
+ * Description  :
  ***************************************************************************************/
 
-#ifndef __GLOBAL_DEFS_H__
-#define __GLOBAL_DEFS_H__
+#ifndef __ISSUE_QUEUE_H__
+#define __ISSUE_QUEUE_H__
 
-#include <malloc.h>
-#include <string.h>
-#include <time.h>
-
-/**************************************************************************************/
-/* Constants */
-
-#define TRUE 1
-#define FALSE 0
-
-#define SUCCESS 1
-#define FAILURE 0
-
-#define TAKEN 1
-#define NOT_TAKEN 0
-
-#define MAX_NUM_PROCS 64
-#define MAX_NUM_BPS 5
-
-#define MAX_STR_LENGTH 1024
-#define MAX_SIMULTANEOUS_STRINGS 32 /* default 32 */ /* power of 2 */
-
-#define MAX_CTR 0xffffffffffffffffULL
-#define MAX_SCTR 0x7fffffffffffffffLL
-
-#define MAX_INT64 0x7fffffffffffffffLL
-#define MAX_INT 0x7fffffff
-#define MAX_UNS64 0xffffffffffffffffULL
-#define MAX_UNS 0xffffffffU
-#define MAX_UNS16 0xffffU
-#define MAX_ADDR 0xffffffffffffffffULL
-
-#undef UNUSED
-#define UNUSED(X) (void)(X)
-
-/**************************************************************************************/
-
-#ifndef NULL
-#define NULL ((void*)0x0)
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-/**************************************************************************************/
+#include "op.h"
 
-#endif /* #ifndef __GLOBAL_DEFS_H__ */
+/**************************************************************************************/
+/* External Methods */
+
+void issue_queue_update();
+void issue_queue_wakeup(Op* op);
+void issue_queue_grant(Op* op);
+void issue_queue_reject(Op* op);
+
+// vanilla hps interface
+void alloc_mem_issue_queue(uns num_cores);
+void set_issue_queue(uns8 proc_id);
+void recover_issue_queue();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* #ifndef __ISSUE_QUEUE_H__ */

--- a/src/node_stage.c
+++ b/src/node_stage.c
@@ -55,6 +55,7 @@
 #include "exec_ports.h"
 #include "ft.h"
 #include "icache_stage.h"
+#include "issue_queue.h"
 #include "lsq.h"
 #include "map.h"
 #include "map_rename.h"
@@ -177,7 +178,6 @@ void recover_node_stage() {
   if (ENABLE_GLOBAL_DEBUG_PRINT && DEBUG_NODE_STAGE && DEBUG_RANGE_COND(node->proc_id))
     debug_node_stage();
 
-  flush_ready_list();
   flush_scheduling_buffer();
   flush_rs();
   flush_window();
@@ -258,10 +258,6 @@ void flush_window() {
       ASSERT(node->proc_id, op->op_num > bp_recovery_info->recovery_op_num);
       op->in_node_list = FALSE;
       *last = op->next_node;
-      if (op->state == OS_IN_RS || op->state == OS_READY || op->state == OS_WAIT_FWD) {
-        ASSERT(op->proc_id, node->rs[op->rs_id].rs_op_count > 0);
-        node->rs[op->rs_id].rs_op_count--;
-      }
       if (op->parent_FT)
         ft_free_op(op);
     } else {
@@ -406,7 +402,8 @@ void update_node_stage(Stage_Data* src_sd) {
   /* update the precommit pointer in the ROB */
   node_precommit_update();
 
-  node_issue_queue_update();
+  /* dispatch ops to the issue queue and issue ops into FUs */
+  issue_queue_update();
 
   /* get rid of the ops that are finished */
   node_retire();

--- a/src/op.h
+++ b/src/op.h
@@ -151,10 +151,10 @@ struct Op_struct {
   uns num_srcs;                 // number of map dependencies (order matches srcs_not_rdy_words / wake-up)
   Src_Info* src_info;           /* grown by map (2 -> 8 -> 128, then x2); freed in free_op */
   uns src_info_cap;
-  Bp_Pred_Info bp_pred_l0;      // l0 branch prediction info
-  Bp_Pred_Info bp_pred_main;    // main branch prediction info
-  Btb_Pred_Info btb_pred;       // btb prediction info
-  Bp_Pred_Info* bp_pred_info;   // selected/active branch prediction info
+  Bp_Pred_Info bp_pred_l0;       // l0 branch prediction info
+  Bp_Pred_Info bp_pred_main;     // main branch prediction info
+  Btb_Pred_Info btb_pred;        // btb prediction info
+  Bp_Pred_Info* bp_pred_info;    // selected/active branch prediction info
   Btb_Pred_Info* btb_pred_info;  // selected/active btb prediction info
   // }}}
 
@@ -189,6 +189,9 @@ struct Op_struct {
   Counter node_id;    // id for position in the node table
   Counter rs_id;      // id for which Reservation Station (RS) this op is assigned to
   Counter chkpt_num;  // id for chkpt (WARNING: this can change due to recoveries)
+
+  uns16 queue_id;        // id for which issue queue this op is assigned to
+  uns16 queue_entry_id;  // id for which entry in the issue queue this op is
 
   struct Op_struct* next_rdy;   // pointer to next ready op (node table)
   Flag in_rdy_list;             // is the op in the node stage's ready list?

--- a/src/op_pool.c
+++ b/src/op_pool.c
@@ -210,6 +210,8 @@ void op_pool_setup_op(uns proc_id, Op* op) {
   op->chkpt_num = MAX_CTR;
   op->node_id = MAX_CTR;
   op->rs_id = MAX_CTR;
+  op->queue_id = MAX_UNS16;
+  op->queue_entry_id = MAX_UNS16;
 
   op->bp_pred_info = NULL;
   op->btb_pred_info = NULL;


### PR DESCRIPTION
The original issue queue does not adapt a physical buffer, and schedules ops in an unrealistic manner. A single ready list is used for seperate reservation stations.
In this patch, a physical issue queue of random organization is implemented, to further support different scheduling methods in the future. Ops in the issue queue is unordered but age matrix pop count can be ultilized to track the relative ages of entries. Round-robin oldest first for serial and parallel picking is implemented.
This patch introduces IPC and KIPS drift.