### PR TITLE
removed callsys check in stall and resolve

### DIFF
--- a/src/decoupled_frontend.cc
+++ b/src/decoupled_frontend.cc
@@ -696,7 +696,7 @@ void Decoupled_FE::stall(Op* op) {
 }
 
 void Decoupled_FE::retire(Op* op, int op_proc_id, uns64 inst_uid) {
-  if ((op->inst_info->table_info.bar_type & BAR_FETCH) || IS_CALLSYS(&op->inst_info->table_info)) {
+  if (op->inst_info->table_info.bar_type & BAR_FETCH) {
     DEBUG(proc_id,
           "[DFE%u] Decoupled fetch saw barrier retire fetch_addr:0x%llx off_path:%i op_num:%llu list_count:%i\n", bp_id,
           op->inst_info->addr, op->off_path, op->op_num, td->seq_op_list.count);

--- a/src/icache_stage.c
+++ b/src/icache_stage.c
@@ -117,7 +117,7 @@ static inline void wp_process_icache_hit(Icache_Data* line, Addr fetch_addr);
 static inline void wp_process_icache_fill(Icache_Data* line, Mem_Req* req);
 
 static inline Flag is_fetch_barrier_op(Op* op) {
-  return (op->inst_info->table_info.bar_type & BAR_FETCH) || IS_CALLSYS(&op->inst_info->table_info);
+  return (op->inst_info->table_info.bar_type & BAR_FETCH);
 }
 
 /**************************************************************************************/

--- a/src/node_stage.c
+++ b/src/node_stage.c
@@ -590,7 +590,7 @@ void node_retire() {
         retired_exit[op->proc_id] = TRUE;
         decoupled_fe_retire(op, op->proc_id, -1);
       } else if (retire_op) {
-        if ((op->inst_info->table_info.bar_type & BAR_FETCH) || IS_CALLSYS(&op->inst_info->table_info)) {
+        if (op->inst_info->table_info.bar_type & BAR_FETCH) {
           icache_resolve_fetch_barrier(op->proc_id, op->inst_uid);
         }
         decoupled_fe_retire(op, op->proc_id, op->inst_uid);


### PR DESCRIPTION
Make IGNORE_BAR_FETCH the single switch for syscall fetch barriers
Drop `IS_CALLSYS` from the matched-pair sites so `BAR_FETCH` is the only
no pref_drift