### PR TITLE
[BUGFIX] Fix LLC stream prefetcher bug

### DIFF
--- a/src/prefetcher/pref_common.c
+++ b/src/prefetcher/pref_common.c
@@ -1235,7 +1235,7 @@ HWP_DynAggr pref_get_degfb(uns8 proc_id, uns8 prefetcher_id) {
             pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id]--;
         } else {  // NOT TIMELY WITH LOW POL
           STAT_EVENT(proc_id, PREF_ACC4_LT_LP);
-          ret = AGGR_DEC;
+          ret = AGGR_INC;
           if (pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id] > 0)
             pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id]--;
         }

--- a/src/prefetcher/pref_common.c
+++ b/src/prefetcher/pref_common.c
@@ -1236,8 +1236,8 @@ HWP_DynAggr pref_get_degfb(uns8 proc_id, uns8 prefetcher_id) {
         } else {  // NOT TIMELY WITH LOW POL
           STAT_EVENT(proc_id, PREF_ACC4_LT_LP);
           ret = AGGR_INC;
-          if (pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id] > 0)
-            pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id]--;
+          if (pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id] < PREF_MAX_DEGFB)
+            pref_table[prefetcher_id].hwp_info->dyn_degree_core[proc_id]++;
         }
       }
     }


### PR DESCRIPTION
The LLC stream prefetcher currently decreases aggressiveness when operating in a low-accuracy, low-timeliness regime which leads to a feedback loop (where it prefetches lesser and lesser), leading to the prefetcher never being able to increase its effectiveness.

This PR aims to fix this bug by increasing prefetcher aggressiveness in a low-accuracy, low-timeliness regime.