### PR TITLE
[FEATURE] Impl of AMD Bulldozer Random Sched Policy

### DIFF
--- a/src/core.param.def
+++ b/src/core.param.def
@@ -152,16 +152,8 @@ DEF_PARAM(reg_renaming_move_eliminate, REG_RENAMING_MOVE_ELIMINATE, Flag, Flag, 
 
 /********ISSUE QUEUE
  * PARAMETERS********************************************************/
-/*
- * FIND_EMPTIEST_RS : 0 (default)
- */
-DEF_PARAM(node_issue_queue_dispatch_scheme, NODE_ISSUE_QUEUE_DISPATCH_SCHEME, uns, uns, 0, )
-
-/*
- * OLDEST_FIRST : 0 (default)
- */
-DEF_PARAM(node_issue_queue_schedule_scheme, NODE_ISSUE_QUEUE_SCHEDULE_SCHEME, uns, uns, 0, )
-
+DEF_PARAM(issue_queue_schedule_policy, ISSUE_QUEUE_SCHEDULE_POLICY, uns, uns, 0, )
+DEF_PARAM(issue_queue_traversal_policy, ISSUE_QUEUE_TRAVERSAL_POLICY, uns, uns, 0, )
 DEF_PARAM(issue_queue_early_bind_policy, ISSUE_QUEUE_EARLY_BIND_POLICY, uns, uns, 1, )
 
 /********EXEC PORT

--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -393,18 +393,47 @@ bool SelectLogic::has_ready_ops() const {
 }
 
 /**************************************************************************************/
-/* Implementation */
 
-// OldestFirstSchedulePolicy prioritize the older ops
+/*
+ * OldestFirstSchedulePolicy prioritize the older ops
+ */
 class OldestFirstSchedulePolicy : public SchedulePolicy {
  public:
-  bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const override;
+  bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const override {
+    return lhs->op->op_num < rhs->op->op_num;
+  }
 };
 
-bool OldestFirstSchedulePolicy::compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const {
-  ASSERT(node->proc_id, lhs != nullptr && rhs != nullptr);
-  return lhs->op->op_num < rhs->op->op_num;
-}
+/*
+ * AMDBulldozerSchedulePolicy is introduced in "40-Entry Unified Out-of-Order Scheduler
+ * and Integer Execution Unit for the AMD Bulldozer x86-64 Core", ISSCC 2011.
+ * The oldest ready instruction will be picked first. Otherwise, a priority encoder scans ready
+ * instructions in physical order.
+ */
+class AMDBulldozerSchedulePolicy : public SchedulePolicy {
+ public:
+  bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const override {
+    if (lhs->op->op_num == node->node_head->op_num)
+      return true;
+
+    if (rhs->op->op_num == node->node_head->op_num)
+      return false;
+
+    return lhs->entry_id < rhs->entry_id;
+  }
+};
+
+/*
+ * RandomSchedulePolicy selects ready ops in their physical order in the issue queue
+ */
+class RandomSchedulePolicy : public SchedulePolicy {
+ public:
+  bool compare(const IssueQueueEntry* lhs, const IssueQueueEntry* rhs) const override {
+    return lhs->entry_id < rhs->entry_id;
+  }
+};
+
+/**************************************************************************************/
 
 // RoundRobinTraversalPolicy ensures fairness by rotating through pickers in a circular manner.
 class RoundRobinTraversalPolicy : public TraversalPolicy {
@@ -414,16 +443,14 @@ class RoundRobinTraversalPolicy : public TraversalPolicy {
 
  public:
   explicit RoundRobinTraversalPolicy(size_t fu_num) : fu_num(fu_num), rr_idx(fu_num - 1) {}
-  void build_picker_order(std::vector<size_t>& picker_order) override;
-};
-
-void RoundRobinTraversalPolicy::build_picker_order(std::vector<size_t>& picker_order) {
-  ASSERT(node->proc_id, picker_order.size() == fu_num);
-  rr_idx = (rr_idx + 1) % fu_num;
-  for (size_t i = 0; i < fu_num; ++i) {
-    picker_order[i] = (rr_idx + i) % fu_num;
+  void build_picker_order(std::vector<size_t>& picker_order) override {
+    ASSERT(node->proc_id, picker_order.size() == fu_num);
+    rr_idx = (rr_idx + 1) % fu_num;
+    for (size_t i = 0; i < fu_num; ++i) {
+      picker_order[i] = (rr_idx + i) % fu_num;
+    }
   }
-}
+};
 
 /**************************************************************************************/
 
@@ -491,10 +518,29 @@ class LeastBindPolicy : public BindPolicy {
 
 class IssueQueuePolicyFactory {
  public:
-  std::unique_ptr<SchedulePolicy> make_schedule_policy() { return std::make_unique<OldestFirstSchedulePolicy>(); }
+  std::unique_ptr<SchedulePolicy> make_schedule_policy() {
+    using SchedulePolicyMaker = std::unique_ptr<SchedulePolicy> (*)();
+    static const SchedulePolicyMaker schedule_policy_makers[ISSUE_QUEUE_SCHEDULE_POLICY_NUM] = {
+        []() -> std::unique_ptr<SchedulePolicy> { return std::make_unique<OldestFirstSchedulePolicy>(); },
+        []() -> std::unique_ptr<SchedulePolicy> { return std::make_unique<AMDBulldozerSchedulePolicy>(); },
+        []() -> std::unique_ptr<SchedulePolicy> { return std::make_unique<RandomSchedulePolicy>(); },
+    };
+
+    ASSERT(node->proc_id, ISSUE_QUEUE_SCHEDULE_POLICY < ISSUE_QUEUE_SCHEDULE_POLICY_NUM);
+    return schedule_policy_makers[ISSUE_QUEUE_SCHEDULE_POLICY]();
+  }
 
   std::unique_ptr<TraversalPolicy> make_traversal_policy(size_t fu_num) {
     return std::make_unique<RoundRobinTraversalPolicy>(fu_num);
+    using TraversalPolicyMaker = std::unique_ptr<TraversalPolicy> (*)(size_t);
+    static const TraversalPolicyMaker traversal_policy_makers[ISSUE_QUEUE_TRAVERSAL_POLICY_NUM] = {
+        [](size_t fu_num) -> std::unique_ptr<TraversalPolicy> {
+          return std::make_unique<RoundRobinTraversalPolicy>(fu_num);
+        },
+    };
+
+    ASSERT(node->proc_id, ISSUE_QUEUE_TRAVERSAL_POLICY < ISSUE_QUEUE_TRAVERSAL_POLICY_NUM);
+    return traversal_policy_makers[ISSUE_QUEUE_TRAVERSAL_POLICY](fu_num);
   }
 
   std::unique_ptr<BindPolicy> make_bind_policy(size_t fu_num) {
@@ -504,7 +550,7 @@ class IssueQueuePolicyFactory {
         [](size_t fu_num) -> std::unique_ptr<BindPolicy> { return std::make_unique<LeastBindPolicy>(fu_num); },
     };
 
-    ASSERT(0, ISSUE_QUEUE_EARLY_BIND_POLICY < ISSUE_QUEUE_EARLY_BIND_POLICY_NUM);
+    ASSERT(node->proc_id, ISSUE_QUEUE_EARLY_BIND_POLICY < ISSUE_QUEUE_EARLY_BIND_POLICY_NUM);
     return bind_policy_makers[ISSUE_QUEUE_EARLY_BIND_POLICY](fu_num);
   }
 };

--- a/src/issue_queue.h
+++ b/src/issue_queue.h
@@ -39,6 +39,18 @@ extern "C" {
 /**************************************************************************************/
 /* Constexpr */
 
+enum IssueQueueSchedulePolicy {
+  ISSUE_QUEUE_SCHEDULE_POLICY_OLDEST_FIRST,
+  ISSUE_QUEUE_SCHEDULE_POLICY_AMD_BULLDOZER,
+  ISSUE_QUEUE_SCHEDULE_POLICY_RANDOM,
+  ISSUE_QUEUE_SCHEDULE_POLICY_NUM
+};
+
+enum IssueQueueTraversalPolicy {
+  ISSUE_QUEUE_TRAVERSAL_POLICY_ROUND_ROBIN,
+  ISSUE_QUEUE_TRAVERSAL_POLICY_NUM
+};
+
 enum IssueQueueEarlyBindPolicy {
   ISSUE_QUEUE_EARLY_BIND_POLICY_NONE,
   ISSUE_QUEUE_EARLY_BIND_POLICY_LEAST,


### PR DESCRIPTION
This patch introduces AMD Bulldozer random scheduling policy. It prioritizes one oldest op if ready, and picks ready ops in physical order.
No perf drift when the policy is not selected.