### PR TITLE
Extract register values in PIN and deliver to Scarab

### DIFF
--- a/src/bp/bp.c
+++ b/src/bp/bp.c
@@ -96,6 +96,7 @@ extern void tc_do_stat(Op*, Flag);
     }                                                                      \
   } while (0)
 
+#define REG_RING_LEN 4096
 /******************************************************************************/
 /* Global Variables */
 
@@ -106,6 +107,9 @@ extern uns operating_mode;
 
 static Hash_Table branch_pc_stats_table;
 static Flag branch_pc_stats_inited = FALSE;
+static Reg_Ring_Entry reg_ring[MAX_NUM_PROCS][REG_RING_LEN];
+static uns reg_ring_head[MAX_NUM_PROCS];
+static uns reg_ring_fill[MAX_NUM_PROCS];
 
 static void init_branch_pc_stats(void) {
   if (branch_pc_stats_inited)
@@ -1029,4 +1033,47 @@ void bp_sync(Bp_Data* bp_data_src, Bp_Data* bp_data_dst) {
   bp_data_dst->on_path_pred = bp_data_src->on_path_pred;
   bp_crs_sync(bp_data_src, bp_data_dst);
   bp_predictors_sync(bp_data_src, bp_data_dst);
+}
+
+void reg_ring_push(Op* op) {
+  uns p = op->proc_id;
+  Reg_Ring_Entry* e = &reg_ring[p][reg_ring_head[p]];
+  e->inst_uid = op->inst_uid;
+  e->pc       = op->inst_info->addr;
+  
+  for (int i = 0; i < NUM_REG_SNAPSHOT; i++) 
+    e->regs[i] = op->reg_snapshot[i];
+
+  reg_ring_head[p] = (reg_ring_head[p] + 1) % REG_RING_LEN;
+
+  if (reg_ring_fill[p] < REG_RING_LEN) 
+    reg_ring_fill[p]++;
+}
+
+void reg_ring_rewind(uns p, uns64 recovery_inst_uid) {
+  Flag had_entries = (reg_ring_fill[p] > 0);
+
+  while (reg_ring_fill[p] > 0) {
+    uns last = (reg_ring_head[p] + REG_RING_LEN - 1) % REG_RING_LEN;
+
+    if (reg_ring[p][last].inst_uid <= recovery_inst_uid) 
+      break;
+
+    reg_ring_head[p] = last;
+    reg_ring_fill[p]--;
+  }
+
+  ASSERTM(p, !had_entries || reg_ring_fill[p] > 0,
+          "reg_ring overrun: recovery uid %llu overwritten "
+          "(wrong-path depth >= %d). Increase REG_RING_LEN.\n",
+          (unsigned long long)recovery_inst_uid, REG_RING_LEN);
+}
+
+const Reg_Ring_Entry* reg_ring_back(uns p, uns n_back) {
+  if (n_back >= reg_ring_fill[p]) 
+    return NULL;
+
+  uns idx = (reg_ring_head[p] + REG_RING_LEN - 1 - n_back) % REG_RING_LEN;
+
+  return &reg_ring[p][idx];
 }

--- a/src/bp/bp.c
+++ b/src/bp/bp.c
@@ -1039,14 +1039,14 @@ void reg_ring_push(Op* op) {
   uns p = op->proc_id;
   Reg_Ring_Entry* e = &reg_ring[p][reg_ring_head[p]];
   e->inst_uid = op->inst_uid;
-  e->pc       = op->inst_info->addr;
-  
-  for (int i = 0; i < NUM_REG_SNAPSHOT; i++) 
+  e->pc = op->inst_info->addr;
+
+  for (int i = 0; i < NUM_REG_SNAPSHOT; i++)
     e->regs[i] = op->reg_snapshot[i];
 
   reg_ring_head[p] = (reg_ring_head[p] + 1) % REG_RING_LEN;
 
-  if (reg_ring_fill[p] < REG_RING_LEN) 
+  if (reg_ring_fill[p] < REG_RING_LEN)
     reg_ring_fill[p]++;
 }
 
@@ -1056,7 +1056,7 @@ void reg_ring_rewind(uns p, uns64 recovery_inst_uid) {
   while (reg_ring_fill[p] > 0) {
     uns last = (reg_ring_head[p] + REG_RING_LEN - 1) % REG_RING_LEN;
 
-    if (reg_ring[p][last].inst_uid <= recovery_inst_uid) 
+    if (reg_ring[p][last].inst_uid <= recovery_inst_uid)
       break;
 
     reg_ring_head[p] = last;
@@ -1070,7 +1070,7 @@ void reg_ring_rewind(uns p, uns64 recovery_inst_uid) {
 }
 
 const Reg_Ring_Entry* reg_ring_back(uns p, uns n_back) {
-  if (n_back >= reg_ring_fill[p]) 
+  if (n_back >= reg_ring_fill[p])
     return NULL;
 
   uns idx = (reg_ring_head[p] + REG_RING_LEN - 1 - n_back) % REG_RING_LEN;

--- a/src/bp/bp.h
+++ b/src/bp/bp.h
@@ -263,7 +263,7 @@ typedef struct Br_Conf_struct {
 
 typedef struct Reg_Ring_Entry_struct {
   uns64 inst_uid;
-  Addr  pc;
+  Addr pc;
   uns64 regs[NUM_REG_SNAPSHOT];
 } Reg_Ring_Entry;
 

--- a/src/bp/bp.h
+++ b/src/bp/bp.h
@@ -261,6 +261,12 @@ typedef struct Br_Conf_struct {
                                  when a misprediction is realized */
 } Br_Conf;
 
+typedef struct Reg_Ring_Entry_struct {
+  uns64 inst_uid;
+  Addr  pc;
+  uns64 regs[NUM_REG_SNAPSHOT];
+} Reg_Ring_Entry;
+
 /**************************************************************************************/
 /* External variables */
 
@@ -304,6 +310,9 @@ Flag is_h2p_at_decode(Addr pc);
 Flag is_h2p_at_exec(Addr pc);
 void reset_h2p_stats(void);
 
+void reg_ring_push(Op* op);
+void reg_ring_rewind(uns proc_id, uns64 recovery_inst_uid);
+const Reg_Ring_Entry* reg_ring_back(uns proc_id, uns n_back);
 /**************************************************************************************/
 
 #endif /* #ifndef __BP_H__ */

--- a/src/ctype_pin_inst.h
+++ b/src/ctype_pin_inst.h
@@ -39,6 +39,7 @@
 #define MAX_LD_NUM 8
 #define MAX_ST_NUM 8
 #define DUMMY_NOP_SIZE 3
+#define NUM_REG_SNAPSHOT 17
 
 typedef uint8_t compressed_reg_t;
 
@@ -143,6 +144,7 @@ typedef struct ctype_pin_inst_struct {
   uint8_t scarab_marker_roi_begin : 1;
   // used to flag scarab marker roi begin
   uint8_t scarab_marker_roi_end : 1;
+  uint64_t reg_snapshot[NUM_REG_SNAPSHOT];
 } __attribute__((packed)) ctype_pin_inst;
 
 typedef ctype_pin_inst compressed_op;

--- a/src/frontend/pin_exec_driven_fe.cc
+++ b/src/frontend/pin_exec_driven_fe.cc
@@ -39,6 +39,7 @@ extern "C" {
 
 #include "op.h"
 #include "sim.h"
+#include "bp/bp.h"
 }
 
 #include <time.h>
@@ -133,6 +134,10 @@ void pin_exec_driven_fetch_op(uns proc_id, uns bp_id, Op* op) {
   update_op_buffer_if_empty(proc_id);
 
   Flag eom = uop_generator_extract_op(proc_id, op, &cached_cop_buffers[proc_id].front());
+
+  if (op->bom) 
+    reg_ring_push(op);
+
   if (eom) {
     if (!decoupled_fe_is_off_path()) {
       if (cached_cop_buffers[proc_id].front().scarab_marker_roi_begin == true) {
@@ -168,6 +173,7 @@ void pin_exec_driven_redirect(uns proc_id, uns bp_id, uns64 inst_uid, Addr fetch
 
   server->send(proc_id, (Message<Scarab_To_Pin_Msg>)msg);  // blocking
   invalidate_op_buffer(proc_id);
+  reg_ring_rewind(proc_id, inst_uid);
   DEBUG(proc_id, "Fetch Redirect end: %llx\n", fetch_addr);
 }
 
@@ -183,6 +189,7 @@ void pin_exec_driven_recover(uns proc_id, uns bp_id, uns64 inst_uid) {
 
   server->send(proc_id, (Message<Scarab_To_Pin_Msg>)msg);  // blocking
   invalidate_op_buffer(proc_id);
+  reg_ring_rewind(proc_id, inst_uid);
   DEBUG(proc_id, "Fetch Recover end: %llu\n", inst_uid);
 }
 

--- a/src/frontend/pin_exec_driven_fe.cc
+++ b/src/frontend/pin_exec_driven_fe.cc
@@ -37,9 +37,10 @@ extern "C" {
 
 #include "general.param.h"
 
+#include "bp/bp.h"
+
 #include "op.h"
 #include "sim.h"
-#include "bp/bp.h"
 }
 
 #include <time.h>
@@ -135,7 +136,7 @@ void pin_exec_driven_fetch_op(uns proc_id, uns bp_id, Op* op) {
 
   Flag eom = uop_generator_extract_op(proc_id, op, &cached_cop_buffers[proc_id].front());
 
-  if (op->bom) 
+  if (op->bom)
     reg_ring_push(op);
 
   if (eom) {

--- a/src/op.h
+++ b/src/op.h
@@ -145,6 +145,7 @@ struct Op_struct {
   Counter unique_num;           // unique number for each instance of an op (not reset on recovery)
   Counter unique_num_per_proc;  // unique number per core
   uns64 inst_uid;               // unique number for the macro instruction provided by the frontend (PIN)
+  uns64 reg_snapshot[NUM_REG_SNAPSHOT];  // GPR(0-15)+RFLAGS(16)
   Inst_Info* inst_info;         // pointer to unique struct for each static instruction
   Op_Info oracle_info;          // information about the execution of the op in the oracle
   Op_Info engine_info;          // information about the execution of the op in the engine

--- a/src/pin/pin_exec/exception_handling.cc
+++ b/src/pin/pin_exec/exception_handling.cc
@@ -226,7 +226,7 @@ bool excp_main_loop(int sig) {
       if(found_syscall)
         have_consumed_op = true;
       else
-        do_fe_null(have_consumed_op);
+        do_fe_null(have_consumed_op, nullptr);
     }
     // We always have a scarab command
     buffer_ready               = scarab_buffer_full() || pending_syscall;

--- a/src/pin/pin_exec/main_loop.cc
+++ b/src/pin/pin_exec/main_loop.cc
@@ -323,12 +323,11 @@ void do_fe_null(bool& have_consumed_op, CONTEXT* ctxt) {
       }
       cop->inst_uid = uid_ctr;
 
-      if(ctxt) {
-        static const REG snap_regs[NUM_REG_SNAPSHOT] = {
-          REG_RAX, REG_RBX, REG_RCX, REG_RDX, REG_RSI, REG_RDI, REG_RBP, REG_RSP,
-          REG_R8,  REG_R9,  REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15,
-          REG_RFLAGS};
-        for(int i = 0; i < NUM_REG_SNAPSHOT; i++)
+      if (ctxt) {
+        static const REG snap_regs[NUM_REG_SNAPSHOT] = {REG_RAX, REG_RBX, REG_RCX, REG_RDX, REG_RSI,   REG_RDI,
+                                                        REG_RBP, REG_RSP, REG_R8,  REG_R9,  REG_R10,   REG_R11,
+                                                        REG_R12, REG_R13, REG_R14, REG_R15, REG_RFLAGS};
+        for (int i = 0; i < NUM_REG_SNAPSHOT; i++)
           cop->reg_snapshot[i] = (uint64_t)PIN_GetContextReg(ctxt, snap_regs[i]);
       }
 

--- a/src/pin/pin_exec/main_loop.cc
+++ b/src/pin/pin_exec/main_loop.cc
@@ -238,7 +238,7 @@ void main_loop(CONTEXT* ctxt) {
     } else if(cmd.type == FE_FETCH_OP) {
       do_fe_fetch_op(syscall_has_been_sent_to_scarab);
     } else if(cmd.type == FE_NULL) {
-      do_fe_null(have_consumed_op);
+      do_fe_null(have_consumed_op, ctxt);
     }
 
     buffer_ready               = scarab_buffer_full() || pending_syscall;
@@ -291,7 +291,7 @@ void do_fe_fetch_op(bool& syscall_has_been_sent_to_scarab) {
   }
 }
 
-void do_fe_null(bool& have_consumed_op) {
+void do_fe_null(bool& have_consumed_op, CONTEXT* ctxt) {
   DBG_PRINT(uid_ctr, dbg_print_start_uid, dbg_print_end_uid,
             "fenull curr_uid=%" PRIu64 "\n", uid_ctr);
   if(!have_consumed_op) {
@@ -322,6 +322,15 @@ void do_fe_null(bool& have_consumed_op) {
                   cop->num_ld, cop->num_st, cop->exit, cop->size);
       }
       cop->inst_uid = uid_ctr;
+
+      if(ctxt) {
+        static const REG snap_regs[NUM_REG_SNAPSHOT] = {
+          REG_RAX, REG_RBX, REG_RCX, REG_RDX, REG_RSI, REG_RDI, REG_RBP, REG_RSP,
+          REG_R8,  REG_R9,  REG_R10, REG_R11, REG_R12, REG_R13, REG_R14, REG_R15,
+          REG_RFLAGS};
+        for(int i = 0; i < NUM_REG_SNAPSHOT; i++)
+          cop->reg_snapshot[i] = (uint64_t)PIN_GetContextReg(ctxt, snap_regs[i]);
+      }
 
       if (cop->is_repeat && cop->instruction_addr == prior_rep_eip)
         cop->fetched_instruction = 0;

--- a/src/pin/pin_exec/main_loop.h
+++ b/src/pin/pin_exec/main_loop.h
@@ -31,6 +31,6 @@ bool do_fe_retire(Scarab_To_Pin_Msg& cmd);
 
 void do_fe_fetch_op(bool& syscall_has_been_sent_to_scarab);
 
-void do_fe_null(bool& have_consumed_op);
+void do_fe_null(bool& have_consumed_op, CONTEXT* ctxt);
 
 #endif  // PIN_EXEC_MAIN_LOOP_H__

--- a/src/pin/pin_lib/uop_generator.c
+++ b/src/pin/pin_lib/uop_generator.c
@@ -323,6 +323,7 @@ void uop_generator_get_uop(uns proc_id, Op* op, ctype_pin_inst* inst) {
     convert_pinuop_to_t_uop(proc_id, inst, trace_uop_array);
 
     op->bom = TRUE;
+    memcpy(op->reg_snapshot, inst->reg_snapshot, sizeof(op->reg_snapshot));
     trace_uop = trace_uop_array[0];
     info = trace_uop->info;
     num_uops[proc_id] = info->trace_info.num_uop;


### PR DESCRIPTION
Hi, @hlitz 

## Extract register values in PIN and deliver to Scarab

**Summary**

Capture a per-instruction register snapshot (16 GPRs + RFLAGS) in the PIN exec-driven frontend and deliver it through the op path into a per-core ring buffer on the Scarab side. Wrong-path entries are discarded on misprediction recovery.

**Changes**
- **PIN:** add `NUM_REG_SNAPSHOT=17`; `do_fe_null()` reads registers via `PIN_GetContextReg()` into the packed `ctype_pin_inst`.

```
from PIN side, debugging log
[PIN-SEND] uid=0 pc=0x5555555d2211
rax    0x000000000000024d    r8     0x00005555558437a8
rbx    0x0000555555775b40    r9     0x0000000000000001
rcx    0x00005555558457d0    r10    0xaaaaaaaaaaaaaaab
rdx    0x0000000000000010    r11    0x00007fffe38a7be0
rsi    0x0000000000000013    r12    0x00005555557727c0
rdi    0x000055555582e540    r13    0x00005555558457d8
rbp    0x0000000000000072    r14    0x00005555558437e0
rsp    0x00007fffffffcb00    r15    0x000055555582ae40
                             rflags 0x0000000000000206

from SCARAB side, debugging log
[FE-RECV]  uid=0 pc=0x5555555d2211
rax    0x000000000000024d    r8     0x00005555558437a8
rbx    0x0000555555775b40    r9     0x0000000000000001
rcx    0x00005555558457d0    r10    0xaaaaaaaaaaaaaaab
rdx    0x0000000000000010    r11    0x00007fffe38a7be0
rsi    0x0000000000000013    r12    0x00005555557727c0
rdi    0x000055555582e540    r13    0x00005555558457d8
rbp    0x0000000000000072    r14    0x00005555558437e0
rsp    0x00007fffffffcb00    r15    0x000055555582ae40
                             rflags 0x0000000000000206
```

- **Transport:** mirror `reg_snapshot` onto `Op`; copied in `uop_generator` at `op->bom`.
- **Scarab:** new `Reg_Ring_Entry`(`REG_RING_LEN=4096`) with `reg_ring_push` (on `bom`), `reg_ring_rewind` (on redirect/recover, drops wrong-path), `reg_ring_back` (lookback access).

**Upcoming changes(TBD)**
- Calculating runahead distance at fetch
- Introducing a new TAGE component for the data-dependent predictor

Thanks.
Best regards,