### PR TITLE
Update sync workflow: scarab → scarab_internal on push to main

### DIFF
--- a/.github/workflows/sync-scarab-repos-priv.yml
+++ b/.github/workflows/sync-scarab-repos-priv.yml
@@ -1,4 +1,4 @@
-name: Sync to Public Repo with Original Authors
+name: Sync to scarab_internal on push to main
 
 permissions:
   contents: write
@@ -10,43 +10,35 @@ on:
 
 jobs:
   sync-repos:
-    if: ${{ github.repository == 'litz-lab/scarab_ll' && github.event_name == 'push' }}
+    if: ${{ github.repository == 'litz-lab/scarab' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Private Repository
+      - name: Checkout scarab
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.SCARAB_SYNC_PAT }}
-          fetch-depth: 0  # Ensure we have the full commit history
+          fetch-depth: 0
 
       - name: Configure Git (Keep Original Authors)
         run: |
           git config --global user.email "$(git log -1 --pretty=format:'%ae')"
           git config --global user.name "$(git log -1 --pretty=format:'%an')"
 
-      - name: Force Authentication with Fine-Grained PAT
+      - name: Set up scarab_internal remote
         env:
           PAT: ${{ secrets.SCARAB_SYNC_PAT }}
         run: |
-          if git remote get-url public > /dev/null 2>&1; then
-            git remote set-url public https://${PAT}@github.com/litz-lab/scarab.git
+          if git remote get-url internal > /dev/null 2>&1; then
+            git remote set-url internal https://${PAT}@github.com/litz-lab/scarab_internal.git
           else
-            git remote add public https://${PAT}@github.com/litz-lab/scarab.git
+            git remote add internal https://${PAT}@github.com/litz-lab/scarab_internal.git
           fi
-          git credential reject https://github.com/ || true  # Ensure old credentials are cleared
 
-      - name: Debug PAT Authentication
+      - name: Push to scarab_internal
         env:
           PAT: ${{ secrets.SCARAB_SYNC_PAT }}
+          BOT_USER: "hlitz"
+          BOT_EMAIL: "hlitz@ucsc.edu"
         run: |
-          echo "Testing authentication..."
-          curl -H "Authorization: Bearer $PAT" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/litz-lab/scarab
-
-      - name: Push Updates to Public Repository (Keeping Original Author, Setting Committer)
-        env:
-          PAT: ${{ secrets.SCARAB_SYNC_PAT }}
-          BOT_USER: "hlitz"  # Replace with service account GitHub username
-          BOT_EMAIL: "hlitz@ucsc.edu"  # Replace with service account email
-        run: |
-          GIT_COMMITTER_NAME="$BOT_USER" GIT_COMMITTER_EMAIL="$BOT_EMAIL" git push https://${PAT}@github.com/litz-lab/scarab.git HEAD:main
+          GIT_COMMITTER_NAME="$BOT_USER" GIT_COMMITTER_EMAIL="$BOT_EMAIL" git push https://${PAT}@github.com/litz-lab/scarab_internal.git HEAD:main


### PR DESCRIPTION
## Summary
- Updates the sync workflow to run in `litz-lab/scarab` (public) instead of the old `scarab_ll`
- Changes sync target from the old public repo to `litz-lab/scarab_internal` (private)
- Removes the debug PAT authentication step

## Test plan
- [ ] Verify `SCARAB_SYNC_PAT` secret is set in `scarab` repo with write access to `scarab_internal`
- [ ] Merge and confirm workflow triggers on next push to main