### PR TITLE
Fix LVP off-path recovery and add adaptive backoff

### DIFF
--- a/src/core.param.def
+++ b/src/core.param.def
@@ -188,6 +188,9 @@ DEF_PARAM(store_queue_entry_num, STORE_QUEUE_ENTRY_NUM, uns, uns, 72, )
 /****************** LOAD VALUE PREDICTOR ******************/
 DEF_PARAM(load_value_pred_scheme, LOAD_VALUE_PRED_SCHEME, uns, uns, 0, )
 DEF_PARAM(const_load_addr_pred_threshold, CONST_LOAD_ADDR_PRED_THRESHOLD, uns, uns, 10, )
+DEF_PARAM(const_load_addr_pred_max_conf, CONST_LOAD_ADDR_PRED_MAX_CONF, uns, uns, 255, )
+DEF_PARAM(const_load_addr_pred_max_threshold, CONST_LOAD_ADDR_PRED_MAX_THRESHOLD, uns, uns, 255, )
+DEF_PARAM(const_load_addr_pred_mispred_penalty, CONST_LOAD_ADDR_PRED_MISPRED_PENALTY, uns, uns, 32, )
 
 /********FRONT END STAGE
  * LATENCIES****************************************************/

--- a/src/load_value_pred.cc
+++ b/src/load_value_pred.cc
@@ -87,7 +87,7 @@ static inline void load_value_predictor_debug_print_op(Op* op, int state) {
 }
 
 static inline void load_value_predictor_sched_recovery(Op* op) {
-  if (!op->eom || !per_core_load_value_mispredict[op->proc_id])
+  if (op->off_path || !op->eom || !per_core_load_value_mispredict[op->proc_id])
     return;
 
   per_core_load_value_mispredict[op->proc_id] = FALSE;
@@ -118,6 +118,8 @@ static inline void load_value_predictor_sched_recovery(Op* op) {
 
 static inline void load_value_predictor_process_predict_op(Op* op, Flag is_mispred) {
   ASSERT(op->proc_id, op->table_info->mem_type == MEM_LD);
+  if (op->off_path)
+    return;
 
   // set the metadata to indicate bypassing
   op->load_value_predicted = TRUE;
@@ -126,9 +128,7 @@ static inline void load_value_predictor_process_predict_op(Op* op, Flag is_mispr
 
   if (is_mispred) {
     per_core_load_value_mispredict[op->proc_id] = TRUE;
-    if (!op->off_path) {
-      STAT_EVENT(op->proc_id, LOAD_VALUE_PREDICT_LOADS_ON_PATH_MISPREDICTED);
-    }
+    STAT_EVENT(op->proc_id, LOAD_VALUE_PREDICT_LOADS_ON_PATH_MISPREDICTED);
   }
 }
 
@@ -188,10 +188,22 @@ class NoneLoadValuePredictor : public LoadValuePredictor {
 struct ConstantLoadAddrPredEntry : public PredictorEntry {
   Addr oracle_address;
   uns confidence;
+  uns predict_threshold;
+  uns cooldown;
   bool found;
 
-  ConstantLoadAddrPredEntry() : oracle_address(0), confidence(0), found(false) {}
-  ConstantLoadAddrPredEntry(Addr addr) : oracle_address(addr), confidence(0), found(true) {}
+  ConstantLoadAddrPredEntry()
+      : oracle_address(0),
+        confidence(0),
+        predict_threshold(CONST_LOAD_ADDR_PRED_THRESHOLD),
+        cooldown(0),
+        found(false) {}
+  ConstantLoadAddrPredEntry(Addr addr)
+      : oracle_address(addr),
+        confidence(0),
+        predict_threshold(CONST_LOAD_ADDR_PRED_THRESHOLD),
+        cooldown(0),
+        found(true) {}
 
   bool is_found() const override { return found; }
 };
@@ -237,6 +249,9 @@ PredictorEntry* ConstantLoadAddrPredictor::lookup(Op* op) {
 
 void ConstantLoadAddrPredictor::train(Op* op, PredictorEntry* entry) {
   ASSERT(op->proc_id, op->table_info->mem_type == MEM_LD);
+  if (op->off_path)
+    return;
+
   Addr pc = op->inst_info->addr;
   Addr va = op->oracle_info.va;
 
@@ -246,12 +261,26 @@ void ConstantLoadAddrPredictor::train(Op* op, PredictorEntry* entry) {
     return;
   }
 
+  if (pred_entry->cooldown > 0) {
+    pred_entry->cooldown--;
+  }
+
   // Update confidence based on whether prediction matches actual address
   if (pred_entry->oracle_address == va) {
-    pred_entry->confidence++;
+    if (pred_entry->confidence < CONST_LOAD_ADDR_PRED_MAX_CONF) {
+      pred_entry->confidence++;
+    }
+    if (pred_entry->predict_threshold > CONST_LOAD_ADDR_PRED_THRESHOLD &&
+        pred_entry->confidence >= pred_entry->predict_threshold) {
+      pred_entry->predict_threshold--;
+    }
   } else {
     pred_entry->oracle_address = va;
     pred_entry->confidence = 0;
+    const uns next_threshold = pred_entry->predict_threshold + CONST_LOAD_ADDR_PRED_MISPRED_PENALTY;
+    pred_entry->predict_threshold =
+        next_threshold > CONST_LOAD_ADDR_PRED_MAX_THRESHOLD ? CONST_LOAD_ADDR_PRED_MAX_THRESHOLD : next_threshold;
+    pred_entry->cooldown = pred_entry->predict_threshold;
   }
 }
 
@@ -264,7 +293,7 @@ void ConstantLoadAddrPredictor::infer(Op* op, PredictorEntry* entry) {
   }
 
   // Only make prediction if confidence exceeds threshold
-  if (pred_entry->confidence <= CONST_LOAD_ADDR_PRED_THRESHOLD) {
+  if (pred_entry->cooldown > 0 || pred_entry->confidence <= pred_entry->predict_threshold) {
     return;
   }
 
@@ -326,7 +355,7 @@ void recover_load_value_predictor() {
 /* External Methods */
 
 void load_value_predictor_predict_op(Op* op) {
-  if (op->table_info->mem_type == MEM_LD) {
+  if (op->table_info->mem_type == MEM_LD && !op->off_path) {
     PredictorEntry* entry = predictor->lookup(op);
     predictor->infer(op, entry);
     predictor->train(op, entry);


### PR DESCRIPTION
This PR does the following:- 

 1. **Fix off-path LVP side effects:** skip LVP lookup/infer/train/stats for off-path loads, and prevent off-path EOM ops from scheduling LVP recovery. This stops wrong-path loads from poisoning predictor
     state or triggering real recovery behavior.

  2. **Reduce predictor aggressiveness with adaptive backoff:** each load PC now has its own prediction threshold and cooldown. When a load’s address changes, confidence resets, the threshold is raised by const_load_addr_pred_mispred_penalty, and prediction is disabled for a cooldown period. Only repeated stable on-path executions rebuild confidence and gradually lower the threshold back toward the base threshold.

---------------------------------------------------------------------------------------------------------------------------------------------------------------------

Baseline = No Load Value Predictor
Config1 = Load Value Predictor without fixes
Config2 = Load Value Predictor with fixes

| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.3413 | 2.2930 | -2.06% | 2.3550 | 0.59% |
| spec2017/rate_int/gcc | 1.0620 | 1.0119 | -4.72% | 1.0653 | 0.31% |
| spec2017/rate_int/mcf | 0.8155 | 0.7491 | -8.15% | 0.8219 | 0.79% |
| spec2017/rate_int/omnetpp | 0.9820 | 0.9751 | -0.71% | 0.9927 | 1.08% |
| spec2017/rate_int/xalancbmk | 1.1459 | 1.1181 | -2.43% | 1.1509 | 0.44% |
| spec2017/rate_int/x264 | 4.2183 | 3.4108 | -19.14% | 4.2425 | 0.57% |
| spec2017/rate_int/deepsjeng | 1.9914 | 1.4961 | -24.87% | 2.0113 | 1.00% |
| spec2017/rate_int/leela | 1.7362 | 1.2078 | -30.44% | 1.8327 | 5.56% |
| spec2017/rate_int/exchange2 | 3.7432 | 2.0541 | -45.12% | 3.7737 | 0.82% |
| spec2017/rate_int/xz | 1.7172 | 1.4794 | -13.85% | 1.7399 | 1.32% |
| spec2017/rate_fp/bwaves | 0.9119 | 0.4296 | -52.89% | 0.9115 | -0.05% |
| spec2017/rate_fp/cactuBSSN | 0.6440 | 0.6486 | 0.71% | 0.6489 | 0.75% |
| spec2017/rate_fp/namd | 3.2052 | 1.5938 | -50.28% | 3.2598 | 1.70% |
| spec2017/rate_fp/parest | 1.8168 | 0.6383 | -64.87% | 1.8207 | 0.21% |
| spec2017/rate_fp/povray | 3.1351 | 2.0445 | -34.79% | 3.1700 | 1.11% |
| spec2017/rate_fp/lbm | 1.1735 | 1.1706 | -0.25% | 1.1695 | -0.34% |
| spec2017/rate_fp/wrf | 1.1295 | 0.8189 | -27.50% | 1.1328 | 0.29% |
| spec2017/rate_fp/blender | 2.5676 | 2.1598 | -15.88% | 2.6394 | 2.80% |
| spec2017/rate_fp/cam4 | 1.5469 | 1.1967 | -22.64% | 1.5955 | 3.14% |
| spec2017/rate_fp/imagick | 3.6021 | 4.2195 | 17.14% | 4.2422 | 17.77% |
| spec2017/rate_fp/nab | 1.5424 | 1.5229 | -1.26% | 1.5839 | 2.69% |
| spec2017/rate_fp/fotonik3d | 1.4225 | 1.1505 | -19.12% | 1.4199 | -0.18% |
| spec2017/rate_fp/roms | 1.3192 | 1.0875 | -17.57% | 1.3291 | 0.75% |
| **Avg** | **1.9030** | **1.4990** | **-21.23%** | **1.9526** | **2.60%** |