### PR TITLE
SHiP cache replacement policy improvements

### DIFF
--- a/src/libs/cache_lib.c
+++ b/src/libs/cache_lib.c
@@ -59,11 +59,35 @@
 static inline uns cache_index(Cache* cache, Addr addr, Addr* tag, Addr* tag_full, Addr* line_addr);
 static inline void update_repl_policy(Cache*, Cache_Entry*, uns, uns, Flag);
 static inline Cache_Entry* find_repl_entry(Cache*, uns8, uns, uns*);
+static inline Cache_Entry* find_rrip_repl_entry_no_update(Cache* cache, uns set, uns* way);
+static inline void* cache_insert_strategy_with_pref(Cache* cache, uns8 proc_id, Addr addr, Addr* line_addr,
+                                                    Addr* repl_line_addr, Flag is_prefetch);
 
 /* for ideal replacement */
 static inline void* access_unsure_lines(Cache*, uns, Addr, Flag);
 static inline Cache_Entry* insert_sure_line(Cache*, uns, Addr);
 static inline void invalidate_unsure_line(Cache*, uns, Addr);
+
+typedef struct Cache_Repl_Context_struct {
+  Flag is_prefetch;
+} Cache_Repl_Context;
+
+enum {
+  SHIP_SHCT_BITS = 14,
+  SHIP_SHCT_SIZE = 1 << SHIP_SHCT_BITS,
+  SHIP_SHCT_MASK = SHIP_SHCT_SIZE - 1,
+  SHIP_SHCT_MAX = 7
+};
+
+static inline uns cache_repl_signature_hash(Addr sign) {
+  sign ^= sign >> 33;
+  sign *= 0xff51afd7ed558ccdULL;
+  sign ^= sign >> 33;
+  sign *= 0xc4ceb9fe1a85ec53ULL;
+  sign ^= sign >> 33;
+
+  return (uns)(sign & SHIP_SHCT_MASK);
+}
 
 /**************************************************************************************/
 /* Global Variables */
@@ -317,7 +341,7 @@ void* cache_insert_replpos(Cache* cache, uns8 proc_id, Addr addr, Addr* line_add
   cache_invalidate(cache, addr, line_addr);
 
   if (cache->repl_policy >= REPL_VOID)
-    return cache_insert_strategy(cache, proc_id, addr, line_addr, repl_line_addr);
+    return cache_insert_strategy_with_pref(cache, proc_id, addr, line_addr, repl_line_addr, isPrefetch);
 
   if (cache->repl_policy == REPL_IDEAL) {
     new_line = insert_sure_line(cache, set, tag);
@@ -1036,7 +1060,7 @@ void* cache_insert_lru(Cache* cache, uns8 proc_id, Addr addr, Addr* line_addr, A
   Cache_Entry* new_line;
 
   if (cache->repl_policy >= REPL_VOID)
-    cache_insert_strategy(cache, proc_id, addr, line_addr, repl_line_addr);
+    return cache_insert_strategy(cache, proc_id, addr, line_addr, repl_line_addr);
 
   if (cache->repl_policy == REPL_IDEAL) {
     new_line = insert_sure_line(cache, set, tag);
@@ -1217,21 +1241,20 @@ static inline int cache_get_policy_index(Repl_Policy repl_policy) {
   return policy;
 }
 
-static inline uns cache_repl_signiture(Cache_Entry* cache_entry, Cache_Repl_Signiture sign_type) {
-  uns sign = 0;
+static inline uns cache_repl_signiture(Cache* cache, Cache_Entry* cache_entry, Cache_Repl_Signiture sign_type) {
+  Addr sign = 0;
   switch (sign_type) {
-    case CACHE_REPL_SIGH_PC:
-      break;
-
     case CACHE_REPL_SIGH_MEM:
       sign = cache_entry->base;
+      if (!cache->tag_incl_offset)
+        sign >>= cache->shift_bits;
       break;
 
     default:
       break;
   }
 
-  return sign;
+  return cache_repl_signature_hash(sign);
 }
 
 const static int CACHE_EVENT_HIT = 1;
@@ -1278,11 +1301,17 @@ void init_cache_strategy(Cache* cache, const char* name, uns cache_size, uns ass
   -- called by external func: cache_insert, cache_insert_replpos, cache_insert_lru
 */
 void* cache_insert_strategy(Cache* cache, uns8 proc_id, Addr addr, Addr* line_addr, Addr* repl_line_addr) {
+  return cache_insert_strategy_with_pref(cache, proc_id, addr, line_addr, repl_line_addr, FALSE);
+}
+
+static inline void* cache_insert_strategy_with_pref(Cache* cache, uns8 proc_id, Addr addr, Addr* line_addr,
+                                                    Addr* repl_line_addr, Flag is_prefetch) {
   Addr tag, tag_full;
   uns repl_index;
   Cache_Entry* new_line;
   int policy;
   uns set = cache_index(cache, addr, &tag, &tag_full, line_addr);
+  Cache_Repl_Context repl_context;
 
   // Get the selected strategy (policy)
   policy = cache_get_policy_index(cache->repl_policy);
@@ -1300,7 +1329,9 @@ void* cache_insert_strategy(Cache* cache, uns8 proc_id, Addr addr, Addr* line_ad
   else
     *repl_line_addr = 0;
   repl_policy_func_table[policy].action_repl(cache, new_line, proc_id, tag, tag_full, line_addr, repl_line_addr);
-  repl_policy_func_table[policy].update_insert(cache, proc_id, set, repl_index, NULL);
+  new_line->pref = is_prefetch;
+  repl_context.is_prefetch = is_prefetch;
+  repl_policy_func_table[policy].update_insert(cache, proc_id, set, repl_index, &repl_context);
 
   return new_line->data;
 }
@@ -1327,8 +1358,12 @@ void* cache_access_strategy(Cache* cache, Addr addr, Addr* line_addr, Flag* tag_
     Cache_Entry* line = &cache->entries[set][ii];
 
     if (line->valid && line->tag == tag) {
-      if (update_repl)
+      if (update_repl) {
+        if (line->pref)
+          line->pref = FALSE;
+        cache->num_demand_access++;
         repl_policy_func_table[policy].update_hit(cache, set, ii, NULL);
+      }
 
       *tag_aliasing = line->tag_full != tag_full;
       return line->data;
@@ -1413,6 +1448,28 @@ void general_action_repl(Cache* cache, Cache_Entry* new_line, uns8 proc_id, Addr
   new_line->tag = tag;
   new_line->tag_full = tag_full;
   new_line->base = *line_addr;
+  new_line->outcome = FALSE;
+}
+
+static inline Cache_Entry* find_rrip_repl_entry_no_update(Cache* cache, uns set, uns* way) {
+  int ii;
+  uns8 max_ref = 0;
+
+  for (ii = 0; ii < cache->assoc; ii++) {
+    Cache_Entry* entry = &cache->entries[set][ii];
+
+    if (!entry->valid) {
+      *way = ii;
+      return entry;
+    }
+
+    if (ii == 0 || entry->reference_val > max_ref) {
+      *way = ii;
+      max_ref = entry->reference_val;
+    }
+  }
+
+  return &cache->entries[set][*way];
 }
 
 /**************************************************************************************/
@@ -1515,6 +1572,12 @@ Cache_Entry* nru_update_evict(Cache* cache, uns8 proc_id, uns set, uns* way, voi
   int ii;
   Flag found = FALSE;
 
+  if (if_external) {
+    Cache_Entry* line = find_rrip_repl_entry_no_update(cache, set, way);
+    cache_debug_print_set(cache, set, *way, CACHE_EVENT_EVICT);
+    return line;
+  }
+
   while (!found) {
     // eviction: search the distant line whose RRPV == 1
     for (ii = 0; ii < cache->assoc; ii++) {
@@ -1562,6 +1625,12 @@ void srrip_update_insert(Cache* cache, uns8 proc_id, uns set, uns way, void* arg
 Cache_Entry* srrip_update_evict(Cache* cache, uns8 proc_id, uns set, uns* way, void* arg, Flag if_external) {
   int ii;
   Flag found = FALSE;
+
+  if (if_external) {
+    Cache_Entry* line = find_rrip_repl_entry_no_update(cache, set, way);
+    cache_debug_print_set(cache, set, *way, CACHE_EVENT_EVICT);
+    return line;
+  }
 
   while (!found) {
     // eviction: search the distant line whose RRPV == 2^M - 1
@@ -1709,7 +1778,8 @@ void drrip_update_insert(Cache* cache, uns8 proc_id, uns set, uns way, void* arg
 }
 
 Cache_Entry* drrip_update_evict(Cache* cache, uns8 proc_id, uns set, uns* way, void* arg, Flag if_external) {
-  cache->miss_count[set]++;
+  if (!if_external)
+    cache->miss_count[set]++;
   DEBUG(0, "DRRIP evict count: 0x%x, 0x%llx\n", set, cache->miss_count[set]);
   return srrip_update_evict(cache, proc_id, set, way, arg, if_external);
 }
@@ -1724,9 +1794,24 @@ Cache_Entry* ship_update_evict(Cache* cache, uns8 proc_id, uns set, uns* way, vo
 
 /* Signiture History Counter Table */
 struct ship_shct {
-  Hash_Table shct_hash;
-  Cache_Repl_Signiture shct_key_tpye;
+  uns8* shct;
+  Cache_Repl_Signiture shct_key_type;
 };
+
+static inline uns8* ship_get_shct_entry(Cache* cache, Cache_Entry* line) {
+  struct ship_shct* cache_shct = (struct ship_shct*)cache->predictor;
+  return &cache_shct->shct[cache_repl_signiture(cache, line, cache_shct->shct_key_type)];
+}
+
+static inline void ship_shct_increment(uns8* counter) {
+  if (*counter < SHIP_SHCT_MAX)
+    (*counter)++;
+}
+
+static inline void ship_shct_decrement(uns8* counter) {
+  if (*counter > 0)
+    (*counter)--;
+}
 
 void ship_action_init(Cache* cache, const char* name, uns cache_size, uns assoc, uns line_size, uns data_size,
                       Repl_Policy repl_policy) {
@@ -1737,8 +1822,8 @@ void ship_action_init(Cache* cache, const char* name, uns cache_size, uns assoc,
   /* allocate history table */
   cache->predictor = malloc(sizeof(struct ship_shct));
   struct ship_shct* cache_shct = (struct ship_shct*)cache->predictor;
-  init_hash_table(&cache_shct->shct_hash, "cache repl ship shct", NODE_TABLE_SIZE, sizeof(Counter));
-  cache_shct->shct_key_tpye = CACHE_REPL_SIGH_MEM;
+  cache_shct->shct = (uns8*)calloc(SHIP_SHCT_SIZE, sizeof(uns8));
+  cache_shct->shct_key_type = CACHE_REPL_SIGH_MEM;
 
   /* init outcome and sign for each line */
   for (ii = 0; ii < num_sets; ii++) {
@@ -1754,28 +1839,24 @@ void ship_update_hit(Cache* cache, uns set, uns way, void* arg) {
 
   // prediction update
   cache->entries[set][way].outcome = TRUE;
-  struct ship_shct* cache_shct = (struct ship_shct*)cache->predictor;
-  Counter* cache_shct_entry = (Counter*)hash_table_access(
-      &cache_shct->shct_hash, cache_repl_signiture(&cache->entries[set][way], cache_shct->shct_key_tpye));
-  (*cache_shct_entry)++;
+  uns8* cache_shct_entry = ship_get_shct_entry(cache, &cache->entries[set][way]);
+  ship_shct_increment(cache_shct_entry);
 
   cache_debug_print_set(cache, set, way, CACHE_EVENT_HIT);
 }
 
 void ship_update_insert(Cache* cache, uns8 proc_id, uns set, uns way, void* arg) {
-  struct ship_shct* cache_shct = (struct ship_shct*)cache->predictor;
-  Flag new_entry = FALSE;
-  Counter* cache_shct_entry = (Counter*)hash_table_access_create(
-      &cache_shct->shct_hash, cache_repl_signiture(&cache->entries[set][way], cache_shct->shct_key_tpye), &new_entry);
-  if (new_entry)
-    *cache_shct_entry = 0;
+  Cache_Entry* line = &cache->entries[set][way];
+  uns8* cache_shct_entry = ship_get_shct_entry(cache, line);
+  Cache_Repl_Context* repl_context = (Cache_Repl_Context*)arg;
+  Flag is_prefetch = repl_context && repl_context->is_prefetch;
 
-  if (*cache_shct_entry == 0) {
-    // insertion in distant future
-    cache->entries[set][way].reference_val = RRIP_DISTANT_VAL;
+  if (*cache_shct_entry == 0 && is_prefetch) {
+    // Keep cold prefetch fills conservative until this signature proves useful.
+    line->reference_val = RRIP_DISTANT_VAL;
   } else {
-    // insertion in long-interval future
-    cache->entries[set][way].reference_val = RRIP_DISTANT_VAL - 1;
+    // Demand and trained prefetch fills get one reuse opportunity.
+    line->reference_val = RRIP_DISTANT_VAL - 1;
   }
 
   cache_debug_print_set(cache, set, way, CACHE_EVENT_INSERT);
@@ -1789,14 +1870,9 @@ Cache_Entry* ship_update_evict(Cache* cache, uns8 proc_id, uns set, uns* way, vo
     return line;
 
   // prediction update
-  if (!line->outcome) {
-    cache->entries[set][*way].outcome = TRUE;
-    struct ship_shct* cache_shct = (struct ship_shct*)cache->predictor;
-    Counter* cache_shct_entry = (Counter*)hash_table_access(
-        &cache_shct->shct_hash, cache_repl_signiture(&cache->entries[set][*way], cache_shct->shct_key_tpye));
-
-    if (cache_shct_entry != NULL && (*cache_shct_entry) > 0)
-      (*cache_shct_entry)--;
+  if (line->valid && !line->outcome) {
+    uns8* cache_shct_entry = ship_get_shct_entry(cache, line);
+    ship_shct_decrement(cache_shct_entry);
   }
   line->outcome = FALSE;
 


### PR DESCRIPTION
1. H = Add 14-bit hashed SHCT indexing instead of using the raw line address directly as the predictor index.
2. C = Fix SHCT saturating counter updates so counters clamp correctly in the valid 0..7 range.
3. A = Reduce SHiP insertion aggressiveness: Demand fills insert at RRIP_DISTANT_VAL - 1. (the other 2 subparts were already happening in the baseline SHiP implementation, this is the only change for this technique).

**Summary:-**
H and A provide performance improvements. Overall, (H+A+C) works best (residual drift versus baseline = -0.18%). Counter saturation does not provide gains (and is slightly worse on its own, but works well on top of H and A, and I think, is also important for implementaton correctness.

**SHiP related PMUs:-**

H = Only hashing
C = Only counter saturation
A = Only Aggressiveness reduction

| Metric | Baseline SHiP | H | C | A | H+A | H+A+C |
|---|---:|---:|---:|---:|---:|---:|
| L1_MISS_count | 27,613,574 | 20,912,182 | 27,603,462 | 21,051,533 | 17,064,207 | 17,102,667 |
| L1_ACCESS_count | 330,766,812 | 325,089,585 | 330,999,964 | 326,293,854 | 324,405,005 | 325,080,825 |
| LLC miss fraction | 8.3484% | 6.4327% | 8.3394% | 6.4517% | 5.2602% | 5.2611% |
| L1_DEMAND_MISS_count | 27,446,677 | 20,808,000 | 27,449,017 | 20,923,234 | 16,958,383 | 16,998,025 |
| L1_DEMAND_ACCESS_count | 233,572,438 | 230,823,025 | 233,533,362 | 232,274,520 | 231,492,479 | 231,511,245 |
| LLC demand miss fraction | 11.7508% | 9.0147% | 11.7538% | 9.0080% | 7.3257% | 7.3422% |
| L1_PREF_REQ_MISS_count | 55,225,517 | 57,590,475 | 55,266,458 | 55,595,585 | 57,865,529 | 57,734,082 |
| L1_PREF_ACCESS_count | 203,010,342 | 197,807,113 | 203,264,066 | 195,459,167 | 196,097,810 | 196,772,015 |
| LLC prefetch miss fraction | 27.2033% | 29.1145% | 27.1895% | 28.4436% | 29.5085% | 29.3406% |


---------------------------------------------------------------------------------------------------------------------------------------------------------------------

**Baseline = LRU replacement policy for LLC**
**Config1 = Baseline SHiP replacement policy for LLC**

**Config2 = (H) SHiP replacement policy for LLC**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.2308 | 2.2359 | 0.22% | 2.2391 | 0.37% |
| spec2017/rate_int/gcc | 1.0572 | 1.0379 | -1.83% | 1.0473 | -0.94% |
| spec2017/rate_int/mcf | 0.8055 | 0.6812 | -15.43% | 0.7839 | -2.68% |
| spec2017/rate_int/omnetpp | 0.9429 | 0.8555 | -9.26% | 0.9305 | -1.32% |
| spec2017/rate_int/xalancbmk | 1.1414 | 1.0346 | -9.36% | 1.1216 | -1.73% |
| spec2017/rate_int/x264 | 4.1828 | 4.1563 | -0.63% | 4.1567 | -0.62% |
| spec2017/rate_int/deepsjeng | 1.9765 | 1.9676 | -0.45% | 1.8791 | -4.93% |
| spec2017/rate_int/leela | 1.7361 | 1.7344 | -0.10% | 1.7344 | -0.10% |
| spec2017/rate_int/exchange2 | 3.7260 | 3.7260 | 0.00% | 3.7260 | 0.00% |
| spec2017/rate_int/xz | 1.7006 | 1.5469 | -9.04% | 1.6152 | -5.02% |
| spec2017/rate_fp/bwaves | 0.8550 | 0.6104 | -28.61% | 0.7641 | -10.63% |
| spec2017/rate_fp/cactuBSSN | 0.6248 | 0.4913 | -21.37% | 0.5716 | -8.51% |
| spec2017/rate_fp/namd | 3.2023 | 3.1908 | -0.36% | 3.1955 | -0.21% |
| spec2017/rate_fp/parest | 1.7428 | 1.7073 | -2.03% | 1.7418 | -0.06% |
| spec2017/rate_fp/povray | 3.1202 | 3.1171 | -0.10% | 3.1171 | -0.10% |
| spec2017/rate_fp/lbm | 1.1803 | 1.1616 | -1.59% | 1.1676 | -1.08% |
| spec2017/rate_fp/wrf | 1.1244 | 1.0993 | -2.24% | 1.1204 | -0.36% |
| spec2017/rate_fp/blender | 2.5644 | 2.4228 | -5.52% | 2.4533 | -4.33% |
| spec2017/rate_fp/cam4 | 1.5290 | 1.5990 | 4.58% | 1.5875 | 3.83% |
| spec2017/rate_fp/imagick | 3.6018 | 3.6018 | 0.00% | 3.6018 | 0.00% |
| spec2017/rate_fp/nab | 1.5423 | 1.5413 | -0.07% | 1.5422 | -0.01% |
| spec2017/rate_fp/fotonik3d | 1.4166 | 1.0769 | -23.98% | 1.3834 | -2.34% |
| spec2017/rate_fp/roms | 1.2822 | 1.2691 | -1.02% | 1.2889 | 0.52% |
| **Avg** | **1.8820** | **1.8202** | **-3.28%** | **1.8595** | **-1.19%** |

**Config2 = (A) SHiP replacement policy for LLC**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.2308 | 2.2359 | 0.22% | 2.2633 | 1.46% |
| spec2017/rate_int/gcc | 1.0572 | 1.0379 | -1.83% | 1.0435 | -1.30% |
| spec2017/rate_int/mcf | 0.8055 | 0.6812 | -15.43% | 0.7800 | -3.17% |
| spec2017/rate_int/omnetpp | 0.9429 | 0.8555 | -9.26% | 0.9476 | 0.50% |
| spec2017/rate_int/xalancbmk | 1.1414 | 1.0346 | -9.36% | 1.1442 | 0.25% |
| spec2017/rate_int/x264 | 4.1828 | 4.1563 | -0.63% | 4.1825 | -0.01% |
| spec2017/rate_int/deepsjeng | 1.9765 | 1.9676 | -0.45% | 1.9757 | -0.04% |
| spec2017/rate_int/leela | 1.7361 | 1.7344 | -0.10% | 1.7362 | 0.01% |
| spec2017/rate_int/exchange2 | 3.7260 | 3.7260 | 0.00% | 3.7260 | 0.00% |
| spec2017/rate_int/xz | 1.7006 | 1.5469 | -9.04% | 1.7048 | 0.25% |
| spec2017/rate_fp/bwaves | 0.8550 | 0.6104 | -28.61% | 0.6093 | -28.74% |
| spec2017/rate_fp/cactuBSSN | 0.6248 | 0.4913 | -21.37% | 0.6374 | 2.02% |
| spec2017/rate_fp/namd | 3.2023 | 3.1908 | -0.36% | 3.1973 | -0.16% |
| spec2017/rate_fp/parest | 1.7428 | 1.7073 | -2.03% | 1.7158 | -1.55% |
| spec2017/rate_fp/povray | 3.1202 | 3.1171 | -0.10% | 3.1180 | -0.07% |
| spec2017/rate_fp/lbm | 1.1803 | 1.1616 | -1.59% | 1.1675 | -1.08% |
| spec2017/rate_fp/wrf | 1.1244 | 1.0993 | -2.24% | 1.1074 | -1.51% |
| spec2017/rate_fp/blender | 2.5644 | 2.4228 | -5.52% | 2.5752 | 0.42% |
| spec2017/rate_fp/cam4 | 1.5290 | 1.5990 | 4.58% | 1.6009 | 4.70% |
| spec2017/rate_fp/imagick | 3.6018 | 3.6018 | 0.00% | 3.6018 | 0.00% |
| spec2017/rate_fp/nab | 1.5423 | 1.5413 | -0.07% | 1.5419 | -0.03% |
| spec2017/rate_fp/fotonik3d | 1.4166 | 1.0769 | -23.98% | 1.0757 | -24.06% |
| spec2017/rate_fp/roms | 1.2822 | 1.2691 | -1.02% | 1.2891 | 0.54% |
| **Avg** | **1.8820** | **1.8202** | **-3.28%** | **1.8583** | **-1.26%** |

**Config2 = (C) SHiP replacement policy for LLC**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.2308 | 2.2359 | 0.22% | 2.2359 | 0.23% |
| spec2017/rate_int/gcc | 1.0572 | 1.0379 | -1.83% | 1.0379 | -1.83% |
| spec2017/rate_int/mcf | 0.8055 | 0.6812 | -15.43% | 0.6787 | -15.74% |
| spec2017/rate_int/omnetpp | 0.9429 | 0.8555 | -9.26% | 0.8555 | -9.27% |
| spec2017/rate_int/xalancbmk | 1.1414 | 1.0346 | -9.36% | 1.0346 | -9.36% |
| spec2017/rate_int/x264 | 4.1828 | 4.1563 | -0.63% | 4.1563 | -0.63% |
| spec2017/rate_int/deepsjeng | 1.9765 | 1.9676 | -0.45% | 1.9676 | -0.45% |
| spec2017/rate_int/leela | 1.7361 | 1.7344 | -0.10% | 1.7344 | -0.10% |
| spec2017/rate_int/exchange2 | 3.7260 | 3.7260 | 0.00% | 3.7260 | 0.00% |
| spec2017/rate_int/xz | 1.7006 | 1.5469 | -9.04% | 1.5469 | -9.04% |
| spec2017/rate_fp/bwaves | 0.8550 | 0.6104 | -28.61% | 0.6104 | -28.61% |
| spec2017/rate_fp/cactuBSSN | 0.6248 | 0.4913 | -21.37% | 0.4913 | -21.37% |
| spec2017/rate_fp/namd | 3.2023 | 3.1908 | -0.36% | 3.1908 | -0.36% |
| spec2017/rate_fp/parest | 1.7428 | 1.7073 | -2.03% | 1.7075 | -2.03% |
| spec2017/rate_fp/povray | 3.1202 | 3.1171 | -0.10% | 3.1171 | -0.10% |
| spec2017/rate_fp/lbm | 1.1803 | 1.1616 | -1.59% | 1.1616 | -1.58% |
| spec2017/rate_fp/wrf | 1.1244 | 1.0993 | -2.24% | 1.0993 | -2.23% |
| spec2017/rate_fp/blender | 2.5644 | 2.4228 | -5.52% | 2.4228 | -5.52% |
| spec2017/rate_fp/cam4 | 1.5290 | 1.5990 | 4.58% | 1.5736 | 2.92% |
| spec2017/rate_fp/imagick | 3.6018 | 3.6018 | 0.00% | 3.6018 | 0.00% |
| spec2017/rate_fp/nab | 1.5423 | 1.5413 | -0.07% | 1.5413 | -0.06% |
| spec2017/rate_fp/fotonik3d | 1.4166 | 1.0769 | -23.98% | 1.0769 | -23.98% |
| spec2017/rate_fp/roms | 1.2822 | 1.2691 | -1.02% | 1.2692 | -1.01% |
| **Avg** | **1.8820** | **1.8202** | **-3.28%** | **1.8190** | **-3.35%** |

**Config2 = (H + A) SHiP replacement policy for LLC**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.2308 | 2.2359 | 0.22% | 2.2381 | 0.33% |
| spec2017/rate_int/gcc | 1.0572 | 1.0379 | -1.83% | 1.0479 | -0.88% |
| spec2017/rate_int/mcf | 0.8055 | 0.6812 | -15.43% | 0.7933 | -1.51% |
| spec2017/rate_int/omnetpp | 0.9429 | 0.8555 | -9.26% | 0.9481 | 0.55% |
| spec2017/rate_int/xalancbmk | 1.1414 | 1.0346 | -9.36% | 1.1428 | 0.12% |
| spec2017/rate_int/x264 | 4.1828 | 4.1563 | -0.63% | 4.1825 | -0.01% |
| spec2017/rate_int/deepsjeng | 1.9765 | 1.9676 | -0.45% | 1.8863 | -4.56% |
| spec2017/rate_int/leela | 1.7361 | 1.7344 | -0.10% | 1.7363 | 0.01% |
| spec2017/rate_int/exchange2 | 3.7260 | 3.7260 | 0.00% | 3.7260 | 0.00% |
| spec2017/rate_int/xz | 1.7006 | 1.5469 | -9.04% | 1.7046 | 0.24% |
| spec2017/rate_fp/bwaves | 0.8550 | 0.6104 | -28.61% | 0.7685 | -10.12% |
| spec2017/rate_fp/cactuBSSN | 0.6248 | 0.4913 | -21.37% | 0.6371 | 1.97% |
| spec2017/rate_fp/namd | 3.2023 | 3.1908 | -0.36% | 3.1999 | -0.07% |
| spec2017/rate_fp/parest | 1.7428 | 1.7073 | -2.03% | 1.7424 | -0.02% |
| spec2017/rate_fp/povray | 3.1202 | 3.1171 | -0.10% | 3.1180 | -0.07% |
| spec2017/rate_fp/lbm | 1.1803 | 1.1616 | -1.59% | 1.1680 | -1.04% |
| spec2017/rate_fp/wrf | 1.1244 | 1.0993 | -2.24% | 1.1212 | -0.28% |
| spec2017/rate_fp/blender | 2.5644 | 2.4228 | -5.52% | 2.5724 | 0.31% |
| spec2017/rate_fp/cam4 | 1.5290 | 1.5990 | 4.58% | 1.5868 | 3.78% |
| spec2017/rate_fp/imagick | 3.6018 | 3.6018 | 0.00% | 3.6018 | 0.00% |
| spec2017/rate_fp/nab | 1.5423 | 1.5413 | -0.07% | 1.5428 | 0.03% |
| spec2017/rate_fp/fotonik3d | 1.4166 | 1.0769 | -23.98% | 1.3819 | -2.45% |
| spec2017/rate_fp/roms | 1.2822 | 1.2691 | -1.02% | 1.2935 | 0.88% |
| **Avg** | **1.8820** | **1.8202** | **-3.28%** | **1.8757** | **-0.34%** |

**Config2 = (H + A + C) SHiP replacement policy for LLC**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.2308 | 2.2359 | 0.22% | 2.2237 | -0.32% |
| spec2017/rate_int/gcc | 1.0572 | 1.0379 | -1.83% | 1.0475 | -0.92% |
| spec2017/rate_int/mcf | 0.8055 | 0.6812 | -15.43% | 0.7913 | -1.76% |
| spec2017/rate_int/omnetpp | 0.9429 | 0.8555 | -9.26% | 0.9483 | 0.58% |
| spec2017/rate_int/xalancbmk | 1.1414 | 1.0346 | -9.36% | 1.1423 | 0.07% |
| spec2017/rate_int/x264 | 4.1828 | 4.1563 | -0.63% | 4.1825 | -0.01% |
| spec2017/rate_int/deepsjeng | 1.9765 | 1.9676 | -0.45% | 1.9757 | -0.04% |
| spec2017/rate_int/leela | 1.7361 | 1.7344 | -0.10% | 1.7363 | 0.01% |
| spec2017/rate_int/exchange2 | 3.7260 | 3.7260 | 0.00% | 3.7260 | 0.00% |
| spec2017/rate_int/xz | 1.7006 | 1.5469 | -9.04% | 1.7025 | 0.11% |
| spec2017/rate_fp/bwaves | 0.8550 | 0.6104 | -28.61% | 0.7675 | -10.23% |
| spec2017/rate_fp/cactuBSSN | 0.6248 | 0.4913 | -21.37% | 0.6371 | 1.97% |
| spec2017/rate_fp/namd | 3.2023 | 3.1908 | -0.36% | 3.1992 | -0.09% |
| spec2017/rate_fp/parest | 1.7428 | 1.7073 | -2.03% | 1.7427 | 0.00% |
| spec2017/rate_fp/povray | 3.1202 | 3.1171 | -0.10% | 3.1180 | -0.07% |
| spec2017/rate_fp/lbm | 1.1803 | 1.1616 | -1.59% | 1.1691 | -0.95% |
| spec2017/rate_fp/wrf | 1.1244 | 1.0993 | -2.24% | 1.1213 | -0.28% |
| spec2017/rate_fp/blender | 2.5644 | 2.4228 | -5.52% | 2.5716 | 0.28% |
| spec2017/rate_fp/cam4 | 1.5290 | 1.5990 | 4.58% | 1.5921 | 4.13% |
| spec2017/rate_fp/imagick | 3.6018 | 3.6018 | 0.00% | 3.6018 | 0.00% |
| spec2017/rate_fp/nab | 1.5423 | 1.5413 | -0.07% | 1.5428 | 0.03% |
| spec2017/rate_fp/fotonik3d | 1.4166 | 1.0769 | -23.98% | 1.3820 | -2.44% |
| spec2017/rate_fp/roms | 1.2822 | 1.2691 | -1.02% | 1.2863 | 0.32% |
| **Avg** | **1.8820** | **1.8202** | **-3.28%** | **1.8786** | **-0.18%** |