### PR TITLE
Remove LVP training for off-path ops

### DIFF
--- a/src/load_value_pred.cc
+++ b/src/load_value_pred.cc
@@ -237,6 +237,9 @@ PredictorEntry* ConstantLoadAddrPredictor::lookup(Op* op) {
 
 void ConstantLoadAddrPredictor::train(Op* op, PredictorEntry* entry) {
   ASSERT(op->proc_id, op->table_info->mem_type == MEM_LD);
+  if (op->off_path)
+    return;
+
   Addr pc = op->inst_info->addr;
   Addr va = op->oracle_info.va;
 


### PR DESCRIPTION
This PR disables the load value predictor training for off-path ops (akin to training at commit).

**LVP related PMUs:-**
| Metric | Config1 | Config2 |
|---|---:|---:|
| LOAD_VALUE_PREDICT_LOADS_ON_PATH_PREDICTED_count | 676,508,215 | 429,128,098 |
| LOAD_VALUE_PREDICT_LOADS_ON_PATH_MISPREDICTED_count | 129,583,403 | 2,378,199 |
| Avg. per-simpoint LVP misprediction rate | 20.9454% | 0.9674% |


**IPC statistics:-**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.3413 | 2.2930 | -2.06% | 2.2751 | -2.83% |
| spec2017/rate_int/gcc | 1.0620 | 1.0119 | -4.72% | 1.0587 | -0.31% |
| spec2017/rate_int/mcf | 0.8155 | 0.7491 | -8.15% | 0.8030 | -1.53% |
| spec2017/rate_int/omnetpp | 0.9820 | 0.9751 | -0.71% | 0.9745 | -0.77% |
| spec2017/rate_int/xalancbmk | 1.1459 | 1.1181 | -2.43% | 1.1464 | 0.05% |
| spec2017/rate_int/x264 | 4.2183 | 3.4108 | -19.14% | 4.0210 | -4.68% |
| spec2017/rate_int/deepsjeng | 1.9914 | 1.4961 | -24.87% | 1.8647 | -6.36% |
| spec2017/rate_int/leela | 1.7362 | 1.2078 | -30.44% | 1.7860 | 2.87% |
| spec2017/rate_int/exchange2 | 3.7432 | 2.0541 | -45.12% | 3.0221 | -19.26% |
| spec2017/rate_int/xz | 1.7172 | 1.4794 | -13.85% | 1.7190 | 0.10% |
| spec2017/rate_fp/bwaves | 0.9119 | 0.4296 | -52.89% | 0.9113 | -0.07% |
| spec2017/rate_fp/cactuBSSN | 0.6440 | 0.6486 | 0.71% | 0.6487 | 0.73% |
| spec2017/rate_fp/namd | 3.2052 | 1.5938 | -50.28% | 3.2561 | 1.59% |
| spec2017/rate_fp/parest | 1.8168 | 0.6383 | -64.87% | 1.8108 | -0.34% |
| spec2017/rate_fp/povray | 3.1351 | 2.0445 | -34.79% | 2.3305 | -25.66% |
| spec2017/rate_fp/lbm | 1.1735 | 1.1706 | -0.25% | 1.1709 | -0.22% |
| spec2017/rate_fp/wrf | 1.1295 | 0.8189 | -27.50% | 1.1310 | 0.13% |
| spec2017/rate_fp/blender | 2.5676 | 2.1598 | -15.88% | 2.6292 | 2.40% |
| spec2017/rate_fp/cam4 | 1.5469 | 1.1967 | -22.64% | 1.5804 | 2.16% |
| spec2017/rate_fp/imagick | 3.6021 | 4.2195 | 17.14% | 4.2134 | 16.97% |
| spec2017/rate_fp/nab | 1.5424 | 1.5229 | -1.26% | 1.5846 | 2.74% |
| spec2017/rate_fp/fotonik3d | 1.4225 | 1.1505 | -19.12% | 1.4245 | 0.14% |
| spec2017/rate_fp/roms | 1.3192 | 1.0875 | -17.57% | 1.3301 | 0.82% |
| **Avg** | **1.9030** | **1.4990** | **-21.23%** | **1.8562** | **-2.46%** |