### PR TITLE
Add per-PC adaptive cooldown to LVP

### DIFF
--- a/src/core.param.def
+++ b/src/core.param.def
@@ -188,6 +188,9 @@ DEF_PARAM(store_queue_entry_num, STORE_QUEUE_ENTRY_NUM, uns, uns, 72, )
 /****************** LOAD VALUE PREDICTOR ******************/
 DEF_PARAM(load_value_pred_scheme, LOAD_VALUE_PRED_SCHEME, uns, uns, 0, )
 DEF_PARAM(const_load_addr_pred_threshold, CONST_LOAD_ADDR_PRED_THRESHOLD, uns, uns, 10, )
+DEF_PARAM(const_load_addr_pred_max_conf, CONST_LOAD_ADDR_PRED_MAX_CONF, uns, uns, 255, )
+DEF_PARAM(const_load_addr_pred_max_threshold, CONST_LOAD_ADDR_PRED_MAX_THRESHOLD, uns, uns, 255, )
+DEF_PARAM(const_load_addr_pred_mispred_penalty, CONST_LOAD_ADDR_PRED_MISPRED_PENALTY, uns, uns, 32, )
 
 /********FRONT END STAGE
  * LATENCIES****************************************************/

--- a/src/load_value_pred.cc
+++ b/src/load_value_pred.cc
@@ -188,10 +188,22 @@ class NoneLoadValuePredictor : public LoadValuePredictor {
 struct ConstantLoadAddrPredEntry : public PredictorEntry {
   Addr oracle_address;
   uns confidence;
+  uns predict_threshold;
+  uns cooldown;
   bool found;
 
-  ConstantLoadAddrPredEntry() : oracle_address(0), confidence(0), found(false) {}
-  ConstantLoadAddrPredEntry(Addr addr) : oracle_address(addr), confidence(0), found(true) {}
+  ConstantLoadAddrPredEntry()
+      : oracle_address(0),
+        confidence(0),
+        predict_threshold(CONST_LOAD_ADDR_PRED_THRESHOLD),
+        cooldown(0),
+        found(false) {}
+  ConstantLoadAddrPredEntry(Addr addr)
+      : oracle_address(addr),
+        confidence(0),
+        predict_threshold(CONST_LOAD_ADDR_PRED_THRESHOLD),
+        cooldown(0),
+        found(true) {}
 
   bool is_found() const override { return found; }
 };
@@ -249,12 +261,28 @@ void ConstantLoadAddrPredictor::train(Op* op, PredictorEntry* entry) {
     return;
   }
 
+  if (pred_entry->cooldown > 0) {
+    pred_entry->cooldown--;
+  }
+
   // Update confidence based on whether prediction matches actual address
   if (pred_entry->oracle_address == va) {
-    pred_entry->confidence++;
+    if (pred_entry->confidence < CONST_LOAD_ADDR_PRED_MAX_CONF) {
+      pred_entry->confidence++;
+    }
+    if (pred_entry->predict_threshold > CONST_LOAD_ADDR_PRED_THRESHOLD &&
+        pred_entry->confidence >= pred_entry->predict_threshold) {
+      pred_entry->predict_threshold--;
+    }
   } else {
     pred_entry->oracle_address = va;
     pred_entry->confidence = 0;
+    const uns next_threshold = pred_entry->predict_threshold + CONST_LOAD_ADDR_PRED_MISPRED_PENALTY;
+    pred_entry->predict_threshold =
+        next_threshold > CONST_LOAD_ADDR_PRED_MAX_THRESHOLD ?
+          CONST_LOAD_ADDR_PRED_MAX_THRESHOLD :
+          next_threshold;
+    pred_entry->cooldown = pred_entry->predict_threshold;
   }
 }
 
@@ -267,7 +295,7 @@ void ConstantLoadAddrPredictor::infer(Op* op, PredictorEntry* entry) {
   }
 
   // Only make prediction if confidence exceeds threshold
-  if (pred_entry->confidence <= CONST_LOAD_ADDR_PRED_THRESHOLD) {
+  if (pred_entry->cooldown > 0 || pred_entry->confidence <= pred_entry->predict_threshold) {
     return;
   }
 

--- a/src/load_value_pred.cc
+++ b/src/load_value_pred.cc
@@ -279,9 +279,7 @@ void ConstantLoadAddrPredictor::train(Op* op, PredictorEntry* entry) {
     pred_entry->confidence = 0;
     const uns next_threshold = pred_entry->predict_threshold + CONST_LOAD_ADDR_PRED_MISPRED_PENALTY;
     pred_entry->predict_threshold =
-        next_threshold > CONST_LOAD_ADDR_PRED_MAX_THRESHOLD ?
-          CONST_LOAD_ADDR_PRED_MAX_THRESHOLD :
-          next_threshold;
+        next_threshold > CONST_LOAD_ADDR_PRED_MAX_THRESHOLD ? CONST_LOAD_ADDR_PRED_MAX_THRESHOLD : next_threshold;
     pred_entry->cooldown = pred_entry->predict_threshold;
   }
 }


### PR DESCRIPTION
This PR adds per-PC adaptive cooldown support to the load value predictor:-

### BEFORE

```text
if load is on-path:
  if PC not in table:
    table[PC] = {addr = actual_addr, conf = 0}
  else if table[PC].addr == actual_addr:
    conf++
  else:
    table[PC].addr = actual_addr
    conf = 0

if PC in table and conf > threshold and addr hits in LLC:
  predict addr
```

### AFTER

```text
if load is on-path:
  if PC not in table:
    table[PC] = {
      addr = actual_addr,
      conf = 0,
      threshold = base,
      cooldown = 0
    }
  else:
    if table[PC].cooldown > 0:
      table[PC].cooldown--

    if table[PC].addr == actual_addr:
      table[PC].conf = min(table[PC].conf + 1, max_conf)

      if table[PC].threshold > base and table[PC].conf >= table[PC].threshold:
        table[PC].threshold--

    else:
      table[PC].addr = actual_addr
      table[PC].conf = 0
      table[PC].threshold = min(table[PC].threshold + penalty, max_threshold)
      table[PC].cooldown = table[PC].threshold

if PC in table and
   table[PC].cooldown == 0 and
   table[PC].conf > table[PC].threshold and
   table[PC].addr hits in L1:
  predict table[PC].addr
```

Baseline = No load value predictor
Config1 = Load value predictor without adaptive cooldown
Config2 = Load value predictor with adaptive cooldown

**LVP related PMUs:-**
| Metric | Config1 | Config2 |
|---|---:|---:|
| LOAD_VALUE_PREDICT_LOADS_ON_PATH_PREDICTED_count | 429,128,098 | 389,750,031 |
| LOAD_VALUE_PREDICT_LOADS_ON_PATH_MISPREDICTED_count | 2,378,199 | 48,207 |
| Avg. per-simpoint LVP misprediction rate | 0.9674% | 0.0234% |

**IPC statistics:-**
| Workload | Baseline IPC | Config1 IPC | Config1 drift | Config2 IPC | Config2 drift |
|---|---:|---:|---:|---:|---:|
| spec2017/rate_int/perlbench | 2.3413 | 2.2751 | -2.83% | 2.3632 | 0.94% |
| spec2017/rate_int/gcc | 1.0620 | 1.0587 | -0.31% | 1.0656 | 0.34% |
| spec2017/rate_int/mcf | 0.8155 | 0.8030 | -1.53% | 0.8219 | 0.78% |
| spec2017/rate_int/omnetpp | 0.9820 | 0.9745 | -0.77% | 0.9969 | 1.52% |
| spec2017/rate_int/xalancbmk | 1.1459 | 1.1464 | 0.05% | 1.1511 | 0.45% |
| spec2017/rate_int/x264 | 4.2183 | 4.0210 | -4.68% | 4.2425 | 0.57% |
| spec2017/rate_int/deepsjeng | 1.9914 | 1.8647 | -6.36% | 2.0103 | 0.95% |
| spec2017/rate_int/leela | 1.7362 | 1.7860 | 2.87% | 1.8333 | 5.59% |
| spec2017/rate_int/exchange2 | 3.7432 | 3.0221 | -19.26% | 3.7632 | 0.53% |
| spec2017/rate_int/xz | 1.7172 | 1.7190 | 0.10% | 1.7370 | 1.15% |
| spec2017/rate_fp/bwaves | 0.9119 | 0.9113 | -0.07% | 0.9116 | -0.03% |
| spec2017/rate_fp/cactuBSSN | 0.6440 | 0.6487 | 0.73% | 0.6488 | 0.74% |
| spec2017/rate_fp/namd | 3.2052 | 3.2561 | 1.59% | 3.2605 | 1.73% |
| spec2017/rate_fp/parest | 1.8168 | 1.8108 | -0.34% | 1.8206 | 0.21% |
| spec2017/rate_fp/povray | 3.1351 | 2.3305 | -25.66% | 3.1762 | 1.31% |
| spec2017/rate_fp/lbm | 1.1735 | 1.1709 | -0.22% | 1.1709 | -0.22% |
| spec2017/rate_fp/wrf | 1.1295 | 1.1310 | 0.13% | 1.1329 | 0.30% |
| spec2017/rate_fp/blender | 2.5676 | 2.6292 | 2.40% | 2.6451 | 3.02% |
| spec2017/rate_fp/cam4 | 1.5469 | 1.5804 | 2.16% | 1.5953 | 3.13% |
| spec2017/rate_fp/imagick | 3.6021 | 4.2134 | 16.97% | 4.2422 | 17.77% |
| spec2017/rate_fp/nab | 1.5424 | 1.5846 | 2.74% | 1.5834 | 2.66% |
| spec2017/rate_fp/fotonik3d | 1.4225 | 1.4245 | 0.14% | 1.4240 | 0.11% |
| spec2017/rate_fp/roms | 1.3192 | 1.3301 | 0.82% | 1.3313 | 0.91% |
| **Avg** | **1.9030** | **1.8562** | **-2.46%** | **1.9534** | **2.65%** |