### PR TITLE
Update actions/checkout from v4 to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/compile-scarab.yml
+++ b/.github/workflows/compile-scarab.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [build-and-run-scarab-opt, build-and-run-scarab-dbg, compare-ipc]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: litz-lab/scarab_perf
           path: baseline
@@ -128,7 +128,7 @@ jobs:
     steps:
       # 1) Clone the perf repo (via HTTPS + PAT)
       - name: Checkout perf baseline
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: litz-lab/scarab_perf
           token: ${{ secrets.SCARAB_PERF_PAT }}

--- a/.github/workflows/scarab-sim.yml
+++ b/.github/workflows/scarab-sim.yml
@@ -33,10 +33,10 @@ jobs:
       kips: ${{ steps.kips.outputs.value }}
     steps:
       - name: Checkout Scarab
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout scarab-infra
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: litz-lab/scarab-infra
           path: infra

--- a/.github/workflows/sync-scarab-repos-priv.yml
+++ b/.github/workflows/sync-scarab-repos-priv.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout scarab
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.SCARAB_SYNC_PAT }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Updates `actions/checkout@v4` to `actions/checkout@v5` in all workflow files
- Fixes Node.js 20 deprecation warning — GitHub now forces Node.js 24

## Test plan
- [ ] Verify workflows run without Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)