### PR TITLE
ci: restrict build-and-run-scarab-opt push trigger to litz-lab/scarab only

### DIFF
--- a/.github/workflows/compile-scarab.yml
+++ b/.github/workflows/compile-scarab.yml
@@ -31,6 +31,7 @@ jobs:
       collect_metrics: true
 
   build-and-run-scarab-opt:
+    if: github.event_name == 'pull_request' || github.repository == 'litz-lab/scarab'
     uses: ./.github/workflows/scarab-sim.yml
     with:
       sci_id: top_simpoint


### PR DESCRIPTION
## Summary
- `build-and-run-scarab-opt` had no `if:` condition, so it ran on every push event including in synced repos like `scarab_internal`
- Added `if: github.event_name == 'pull_request' || github.repository == 'litz-lab/scarab'` to restrict push-triggered runs to the source repo only
- PR-triggered runs are unaffected and continue to work in all repos

## Test plan
- [ ] Verify `build-and-run-scarab-opt` runs on this PR in `litz-lab/scarab`
- [ ] After merge, verify a push to `scarab_internal` does NOT trigger `build-and-run-scarab-opt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)