### PR TITLE
fix a broken CI from scarab_internal

### DIFF
--- a/.github/workflows/scarab-sim.yml
+++ b/.github/workflows/scarab-sim.yml
@@ -91,6 +91,9 @@ jobs:
           with open(src) as f:
               d = json.load(f)
           d["application_dir"] = os.environ["GITHUB_WORKSPACE"] + "/"
+          d["scarab_path"] = os.environ["GITHUB_WORKSPACE"] + "/"
+          d["root_dir"] = os.environ["GITHUB_WORKSPACE"] + "/"
+          d["traces_dir"] = os.environ["GITHUB_WORKSPACE"] + "/traces_top_simpoint" 
           src.write_text(json.dumps(d, indent=2, separators=(',', ':')) + "\n")
           PY
         env:

--- a/.github/workflows/scarab-sim.yml
+++ b/.github/workflows/scarab-sim.yml
@@ -93,7 +93,7 @@ jobs:
           d["application_dir"] = os.environ["GITHUB_WORKSPACE"] + "/"
           d["scarab_path"] = os.environ["GITHUB_WORKSPACE"] + "/"
           d["root_dir"] = os.environ["GITHUB_WORKSPACE"] + "/"
-          d["traces_dir"] = os.environ["GITHUB_WORKSPACE"] + "/traces_top_simpoint" 
+          d["traces_dir"] = os.environ["GITHUB_WORKSPACE"] + "/traces_top_simpoint"
           src.write_text(json.dumps(d, indent=2, separators=(',', ':')) + "\n")
           PY
         env:


### PR DESCRIPTION
Hi, @hlitz 

The current CI causes a scarab build failure in the scarab_internal private repo.
(build fail case : https://github.com/litz-lab/scarab_internal/pull/1)

Root cause:
Scarab-infra json descriptors for CI hardcoded scarab_path/root_dir to the public repo's checkout path (like /home/runner/work/scarab/scarab/), breaking repos with other names.

Override them with GITHUB_WORKSPACE at CI script.

Verified on scarab_internal: https://github.com/litz-lab/scarab_internal/pull/2

Thanks.
Best regards,