### PR TITLE
Optimize D-cache operation ordering

### DIFF
--- a/src/dcache_stage.c
+++ b/src/dcache_stage.c
@@ -208,21 +208,32 @@ void update_dcache_stage(Stage_Data* src_sd) {
 
   /* phase 2 - check the dcache port availability and do dcache access */
   int start_op_count = dc->sd.op_count;
-  Counter last_oldest_op_num = 0;
-  for (uns ii = 0; ii < start_op_count; ii++) {
-    /* update in program order (make things easier) */
-    uns oldest_index = 0;
-    Counter oldest_op_num = MAX_CTR;
-    // TODO: adjust this O(n2) algorithm by getting the program order outside first
-    for (uns jj = 0; jj < dc->sd.max_op_count; jj++) {
-      if (dc->sd.ops[jj] && dc->sd.ops[jj]->op_num > last_oldest_op_num && dc->sd.ops[jj]->op_num < oldest_op_num) {
-        oldest_op_num = dc->sd.ops[jj]->op_num;
-        oldest_index = jj;
-      }
-    }
-    last_oldest_op_num = oldest_op_num;
+  uns program_order[STAGE_MAX_OP_COUNT];
+  uns program_order_count = 0;
 
-    ASSERT(dc->proc_id, oldest_op_num < MAX_CTR);
+  /* Determine program order once.  Keep the sort stable so this has the same
+   * tie behavior as the old repeated scan, which selected the lowest stage
+   * index first. */
+  for (uns ii = 0; ii < dc->sd.max_op_count; ii++) {
+    if (dc->sd.ops[ii])
+      program_order[program_order_count++] = ii;
+  }
+  ASSERT(dc->proc_id, program_order_count == start_op_count);
+
+  for (uns ii = 1; ii < program_order_count; ii++) {
+    uns key_index = program_order[ii];
+    Counter key_op_num = dc->sd.ops[key_index]->op_num;
+    int jj = ii - 1;
+
+    while (jj >= 0 && dc->sd.ops[program_order[jj]]->op_num > key_op_num) {
+      program_order[jj + 1] = program_order[jj];
+      jj--;
+    }
+    program_order[jj + 1] = key_index;
+  }
+
+  for (uns ii = 0; ii < start_op_count; ii++) {
+    uns oldest_index = program_order[ii];
     Op* op = dc->sd.ops[oldest_index];
 
     // if the op is replaying, squish it


### PR DESCRIPTION
**Problem**
update_dcache_stage() repeatedly scanned every D-cache stage slot to select the next-oldest live operation. In the validated golden_cove configuration, the stage has at most four live operations. The repeated scan was a small local host-execution optimization opportunity, but the complete function accounts for less than 2% of sampled host cycles.

**Change**
The patch changes only phase two of src/dcache_stage.c:

1. Collect the indices of live stage operations once.
2. Stable insertion-sort those indices by the referenced operation's op_num.
3. Run the existing replay, port, cache, miss, wakeup, and statistics body in that sorted order.
An assertion verifies that the collected live count equals the entry op_count. No modeled cache or memory behavior is intentionally changed.

**Correctness validation**
Validated base commit: 4e1c328
Validated candidate/PR commit: fdef0d1
Architecture: golden_cove
Focused trace: SPEC CPU2017 rate_int_v2/perlbench_r, SimPoint 109678, memtrace
Full provided suite: 106 baseline + 106 optimized trace/SimPoint cases
Completion: 212/212, zero failed, pending, or missing
Scarab regular/warmup CSV and OUT pairs: 3,816 identical after excluding only SIM_HOST_WALL_SECONDS
PARAMS.in, PARAMS.out, and Ramulator pairs: 318 byte-identical
Total comparison: 4,134 matched pairs, zero deterministic differences

**IPC table generated by ./sci --visualize**

Workload | baseline (IPC) | optimized (IPC) | optimized speedup vs baseline (%)
-- | -- | -- | --
spec2017/rate_fp_v2/blender_r | 2.2213 | 2.2213 | 0%
spec2017/rate_fp_v2/bwaves_r | 0.8638 | 0.8638 | 0%
spec2017/rate_fp_v2/bwaves_r_2 | 0.8589 | 0.8589 | 0%
spec2017/rate_fp_v2/bwaves_r_3 | 0.8499 | 0.8499 | 0%
spec2017/rate_fp_v2/bwaves_r_4 | 0.8664 | 0.8664 | 0%
spec2017/rate_fp_v2/cactuBSSN_r | 1.9579 | 1.9579 | 0%
spec2017/rate_fp_v2/cam4_r | 1.3381 | 1.3381 | 0%
spec2017/rate_fp_v2/fotonik3d_r | 1.0462 | 1.0462 | 0%
spec2017/rate_fp_v2/imagick_r | 3.8285 | 3.8285 | 0%
spec2017/rate_fp_v2/lbm_r | 1.1725 | 1.1725 | 0%
spec2017/rate_fp_v2/nab_r | 1.3677 | 1.3677 | 0%
spec2017/rate_fp_v2/namd_r | 3.5624 | 3.5624 | 0%
spec2017/rate_fp_v2/parest_r | 1.6676 | 1.6676 | 0%
spec2017/rate_fp_v2/povray_r | 3.0194 | 3.0194 | 0%
spec2017/rate_fp_v2/roms_r | 1.3133 | 1.3133 | 0%
spec2017/rate_fp_v2/wrf_r | 1.1772 | 1.1772 | 0%
spec2017/rate_int_v2/deepsjeng_r | 2.3622 | 2.3622 | 0%
spec2017/rate_int_v2/exchange2_r | 3.5953 | 3.5953 | 0%
spec2017/rate_int_v2/gcc_r | 1.5691 | 1.5691 | 0%
spec2017/rate_int_v2/gcc_r_2 | 1.7657 | 1.7657 | 0%
spec2017/rate_int_v2/gcc_r_3 | 1.1181 | 1.1181 | 0%
spec2017/rate_int_v2/gcc_r_4 | 1.9015 | 1.9015 | 0%
spec2017/rate_int_v2/gcc_r_5 | 1.8911 | 1.8911 | 0%
spec2017/rate_int_v2/leela_r | 1.6315 | 1.6315 | 0%
spec2017/rate_int_v2/mcf_r | 0.7713 | 0.7713 | 0%
spec2017/rate_int_v2/omnetpp_r | 0.9308 | 0.9308 | 0%
spec2017/rate_int_v2/perlbench_r | 2.7477 | 2.7477 | 0%
spec2017/rate_int_v2/perlbench_r_2 | 3.1037 | 3.1037 | 0%
spec2017/rate_int_v2/perlbench_r_3 | 2.0992 | 2.0992 | 0%
spec2017/rate_int_v2/x264_r | 4.0981 | 4.0981 | 0%
spec2017/rate_int_v2/x264_r_2 | 4.4285 | 4.4285 | 0%
spec2017/rate_int_v2/x264_r_3 | 4.3331 | 4.3331 | 0%
spec2017/rate_int_v2/xalancbmk_r | 1.05 | 1.05 | 0%
spec2017/rate_int_v2/xz_r | 0.8252 | 0.8252 | 0%
spec2017/rate_int_v2/xz_r_2 | 2.2965 | 2.2965 | 0%
spec2017/rate_int_v2/xz_r_3 | 1.5858 | 1.5858 | 0%
Average | 1.9782 | 1.9782 | 0%

**Host-performance evidence**
The original microbenchmark used a synthetic 64-slot stage and overstated the benefit. It was corrected to the production-realistic four-slot capacity.

Corrected four-operation local case |Original	|Index sort|	Change
-- | -- | -- | --
Sorted	|34.619 ns	|20.167 ns	|41.8% lower
Reverse	|33.456 ns	|21.532 ns	|35.6% lower
Mixed	|34.499 ns	|20.804 ns	|39.7% lower

**Matched profiling/counter evidence:**

Metric	|Baseline	|Optimized	|Result
-- | -- | -- | --
update_dcache_stage() self overhead	|1.65%	|1.54%	|−0.11 percentage points
Performance-core cycles	|897.284B	|887.514B	|−1.089%
Performance-core instructions	|1,153.345B	|1,152.899B	|−0.039%
Performance-core branches	|199.228B	|199.095B	|−0.067%
Performance-core branch misses	|4.954B	|4.900B	|−1.088%
Host IPC	|1.28537	|1.29902	|+1.062%
perf stat elapsed	|360.356 s	|357.354 s	|0.833% faster

The exact-final profiled pair took 362.106 seconds baseline and 361.923 seconds optimized (0.050% faster), while the exact-final counter pair was 0.833% faster. These are encouraging matched observations, but one pair of each type does not establish a statistically repeatable whole-program speedup. This PR does not claim a demonstrated 4–5% improvement.
### 
Reproduction

# Build matched binaries
./sci --build-scarab dcache_spec17_pr_final

# Full suite and official outputs
./sci --sim dcache_spec17_pr_final
./sci --status dcache_spec17_pr_final
./sci --collect-stats dcache_spec17_pr_final
./sci --visualize dcache_spec17_pr_final
./sci --perf-analyze dcache_spec17_pr_final

# Strict all-stat comparison
Research/dcache_optimization/scripts/compare_spec17_full_stats.sh \
  /home/kaden-lee/simulations/dcache_spec17_pr_final

# Matched profiles and counters
Research/dcache_optimization/scripts/run_dcache_pr_final_evidence.sh baseline final_profile --profile
Research/dcache_optimization/scripts/run_dcache_pr_final_evidence.sh optimized final_profile --profile
Research/dcache_optimization/scripts/run_dcache_pr_final_evidence.sh baseline final_stat --stat
Research/dcache_optimization/scripts/run_dcache_pr_final_evidence.sh optimized final_stat --stat


**Limitations**
The complete changed function is less than 2% of sampled host cycles.
The selected block is only part of that function.
Local microbenchmark improvement does not establish total runtime improvement.
The refreshed matched counter pair is favorable, but a single pair is not a statistically demonstrated complete-Scarab speedup. 
The change is submitted as a correctness-validated local optimization with conservative performance claims.

