### PR TITLE
prefetcher: universal ChampSim shim (IPCP, MLOP, SPP, IPCP_FULL, IP-s…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ add_subdirectory(ramulator)
 add_subdirectory(pin/pin_lib)
 add_subdirectory(pin/pin_exec/testing)
 
-set(scarab_dirs bp debug bp/template_lib dvfs frontend globals isa libs memory power prefetcher confidence .)
+set(scarab_dirs bp debug bp/template_lib dvfs frontend globals isa libs memory power prefetcher prefetcher/champsim prefetcher/champsim/wrappers confidence .)
 if(DEFINED ENV{SCARAB_ENABLE_PT_MEMTRACE})
   set(scarab_dirs ${scarab_dirs} frontend/pt_memtrace)
 endif()
@@ -81,7 +81,19 @@ foreach(dir IN LISTS scarab_dirs)
     set(srcs ${srcs} ${dir_srcs})
 endforeach()
 
-add_executable(scarab 
+# ChampSim shim: each wrapper TU #includes an UNMODIFIED vendor prefetcher source,
+# which trips warnings (incl. macro redefinitions, which GCC cannot disable via
+# -Wno-* or pragmas) that Scarab's -Werror would otherwise reject. Instead of
+# compiling the whole TU with -w, mark the include tree as system headers for
+# these TUs only (-isystem outranks -I for the same dir): warnings inside the
+# included vendor/env files are suppressed, while code written in the wrapper
+# .cc itself keeps full -Wall -Werror. The shim core (champsim_shim.cc) is a
+# normal TU with full warnings.
+file(GLOB champsim_vendor_tus CONFIGURE_DEPENDS prefetcher/champsim/wrappers/*.cc)
+set_source_files_properties(${champsim_vendor_tus} PROPERTIES COMPILE_OPTIONS
+    "-isystem;${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_executable(scarab
     ${srcs}
 )
 

--- a/src/param_files.def
+++ b/src/param_files.def
@@ -45,3 +45,5 @@
 #include "prefetcher/pref_phase.param.def"
 #include "prefetcher/pref_2dc.param.def"
 #include "prefetcher/pref_markov.param.def"
+#include "prefetcher/champsim/pref_mlop.param.def"
+#include "prefetcher/champsim/pref_ipstride.param.def"

--- a/src/prefetcher/champsim/README.md
+++ b/src/prefetcher/champsim/README.md
@@ -1,0 +1,129 @@
+# Universal ChampSim → Scarab Prefetcher Shim
+
+Drop in an **unmodified** DPC3-era ChampSim prefetcher (`*.l2c_pref` / `*.l1d_pref`) and run it inside
+Scarab's prefetch framework. Glue is written once; adding a prefetcher = drop in the vendor file + a
+~60-line wrapper + a table entry. **Status: original goal met** — universal shim built and verified
+with MLOP and IPCP (plus SPP). Three framework capabilities were added so the shim can match ChampSim
+across cache levels, cooperating components, and eviction training.
+
+## Layout
+
+```
+champsim/
+  champsim_shim.h / .cc      # shim_issue (level routing), level_from_fill, tick, addr helpers, globals
+  csenv/                     # fake ChampSim headers (cache.h, champsim.h, memory_class.h, ooo_cpu.h, spp.h)
+                             # + byte-identical vendor sources as *.inc (diff vs Berti-Artifact = empty)
+  wrappers/                  # one small .cc per import (3 template stubs + hand-written ipcp/mlop)
+  pref_champsim.h            # hook declarations (included by ../pref_common.c before pref_table.def)
+  pref_champsim.stat.def     # shared PREF_SHIM_* counters for all imports
+  pref_<name>.param.def/.h    # only for imports with knobs (mlop, ipstride)
+```
+
+## Mechanism
+
+- Each wrapper `#include`s the vendor `.inc` inside `namespace cs_<name>{}`; `csenv/cache.h` is a
+  concrete `class CACHE`, so each prefetcher gets a distinct `cs_<name>::CACHE` — no ODR collision.
+- ChampSim globals (`NUM_CPUS`, `FILL_*`, `warmup_complete[]`, `ooo_cpu[]`) stay global (pre-included);
+  `ooo_cpu[].num_retired` is wired to Scarab's real `inst_count[]`.
+- `CACHE::prefetch_line()` → `champsim::shim_issue(level, …)` → `pref_addto_{dl0,umlc,ul1}_req_queue`.
+- Vendor TUs compiled with `-w` (CMake `set_source_files_properties`) so vendor warnings don't trip
+  Scarab's `-Werror`. `csenv` is excluded from the build glob (the `.inc` never compile standalone).
+
+## Framework capabilities added (all gated/opt-in; legacy prefetchers unaffected)
+
+1. **Real L1D prefetch fill** — `--pref_dl0_fill_dcache` (default **off**; pass 1 whenever an
+   instance uses `DEST_DCACHE`, else its dcache-queue misses forward to the LLC queue). When on,
+   the DL0 prefetch drain issues
+   `new_mem_req(MRT_DPRF, …, dcache_fill_line, dest=DEST_DCACHE)` so a DL0 prefetch truly fills the
+   L1D (it previously forwarded to LLC). Also fixed a pre-existing dead-code bug in the DL0 drain
+   (`pref_update_core` never freed queue slots). Files: `../pref_common.c`, `../pref.param.def`.
+2. **`cache_fill` / eviction dispatch** — new `ul1_cache_fill` field on `HWP` (`../pref_common.h`),
+   `pref_ul1_cache_fill` dispatch (`../pref_common.c`), call site at the UL1 fill (`../memory/memory.c`,
+   after the L1 `cache_insert`). Mirrors ChampSim `*_prefetcher_cache_fill`; enables eviction-trained
+   prefetchers (SPP, SPP+PPF).
+3. **Inter-level metadata channel** — `_downstream_op` on the shim `CACHE`: an L1 prefetch forwards
+   `(pf_addr, ip, metadata)` to a cooperating L2 component, reproducing ChampSim's L1→L2 `pf_metadata`
+   handoff, for future cooperating two-level imports. (The experimental two-level IPCP that used
+   it was dropped from the PR: its L2 component stays inert without per-line accuracy metadata.)
+
+## Prefetchers (validated)
+
+Enable via the framework instance lists (`--pref_framework_on 1` plus e.g.
+`--pref_num_mlc_prefetchers 1 --pref_mlc_prefetchers TYPE_IPCP,DEST_MLC`): the list a type appears
+in sets its training level, the DEST_* token its destination.
+
+| prefetcher | vendor `.inc` | list token | notes |
+|---|---|---|---|
+| IPCP | `ipcp_isca2020.l1d` | `TYPE_IPCP` | per-class accuracy throttle wired to fills/pref-hits |
+| MLOP | `mlop_dpc3.l1d` | `TYPE_MLOP` | fixed dest (default) or `--pref_mlop_route_by_fill 1` |
+| SPP | `spp.l2c` | `TYPE_SPP` | eviction-trained via `ul1_cache_fill` |
+| IP-stride | `ip_stride.l2c` | `TYPE_IPSTRIDE` | DPC2 baseline; `--pref_ipstride_route_by_fill 1` optional |
+| next-line | `next_line.l2c` | `TYPE_NEXTLINE` | ChampSim's sequential/streaming baseline |
+
+## Add a new ChampSim prefetcher FOO
+
+1. Copy unmodified `foo.<lvl>_pref` → `csenv/foo.<lvl>.inc` (+ any private `.h` it includes).
+2. Write the stub `wrappers/pref_foo.cc` — for a standard vendor this is the whole file:
+   ```c
+   #define SHIM_NAME    foo
+   #define SHIM_VENDOR  "prefetcher/champsim/csenv/foo.l2c.inc"
+   #define SHIM_API_L2C 1              /* or SHIM_API_L1D */
+   #include "prefetcher/champsim/shim_import.h"
+   ```
+   Optional knobs before the include: `SHIM_EXTRA_INIT` / `SHIM_EXTRA_OP` (custom init/operate glue,
+   see `pref_ipstride.cc`) and `SHIM_GEN_UL1_CACHE_FILL` (eviction-trained vendors, see `pref_spp.cc`).
+   Prefetchers needing real custom glue keep hand-written wrappers (`pref_ipcp.cc` and
+   `pref_mlop.cc` are the examples).
+3. Declare the generated hooks in `pref_champsim.h` and add a `pref_table.def` row. Events count
+   into the shared `PREF_SHIM_*` stats automatically; add `.param.def/.param.h` (registered in
+   `../param_files.def`) only if FOO has knobs.
+4. Enable it with the instance lists, e.g. `--pref_num_mlc_prefetchers 1
+   --pref_mlc_prefetchers TYPE_FOO,DEST_MLC`.
+5. Build (`sci --build-scarab`). Never edit vendor source or the shim core per prefetcher.
+
+## Validated results (bwaves_r sp26004; baseline 0.674, stream 1.248)
+
+| config | IPC | note |
+|---|---|---|
+| ipcp @ mlc | 1.241 | **matches hand-port 1.214** |
+| ipcp @ dcache | 1.201 | real L1D fill (DCACHE_MISS 1.2M→39K) |
+| ipcp @ l1 (LLC) | 1.187 | |
+| mlop (collapsed L2, default) | 1.019 | |
+| spp | 1.149 | `PREF_SHIM_CACHE_FILL`=406K (training fires) |
+
+**Caveat:** Scarab IPC ≠ ChampSim/paper IPC (different simulator/baseline) — compare *relative* gains.
+bwaves is a pure stream (stream's best case) and can't differentiate MLOP; use a multi-workload sweep
+(mcf/omnetpp/mongodb/bwaves) for a real per-prefetcher comparison.
+
+## Shim vs hand-port (freshly measured, same arch golden_cove, bwaves_r sp26004)
+
+Hand-port = the prior hand-rewritten ports in `scarab_uop_segment/scarab_ll` (descriptor
+`scarab-infra/json/mlop_handport_cmp.json`); shim = this tree.
+
+| prefetcher | hand-port IPC (base 0.684) | shim IPC (base 0.674) | verdict |
+|---|---|---|---|
+| IPCP @ mlc | 1.232 (1.80x) | 1.241 (1.84x) | **match** (+0.7%) |
+| MLOP @ mlc | 1.169 (1.71x) | 1.019 (1.51x, collapsed default; issued 671K) | shim ~13% lower |
+
+- IPCP: verbatim self-contained IPCP reproduces the hand-written port.
+- MLOP: shim runs the FULL verbatim MLOP (both FILL_L1+FILL_L2 selection tiers → over-prefetches 671K
+  vs the hand-port's leaner L2-only 413K). Matching the hand-port would require de-tuning the vendor's
+  hardcoded thresholds (breaks "verbatim") — an algorithm-faithfulness vs hand-port difference, not a
+  shim defect.
+
+## Known gap / future work
+
+- **Two-level IPCP L2 is inert.** The metadata channel delivers (L2 driven 12M), but the L1 encodes
+  `stride=0` whenever its accuracy < 75%, and accuracy is stuck at the default 60% because per-class
+  `pref_filled`/`pref_useful` aren't populated. Making the L2 issue needs a per-line/per-request
+  32-bit `pf_metadata` field threaded `Pref_Mem_Req`→`Mem_Req`→cache line, with counters updated on
+  fill/pref-hit. Heavy core change; deferred (beyond the original shim goal).
+- SPP+PPF: same pattern as SPP (drop in `ppf.l2c` + wrapper using `ul1_cache_fill`); PPF's perceptron
+  also benefits from the same accuracy feedback.
+- The three framework capabilities are general, low-risk Scarab improvements and could be PR'd to
+  litz-lab/scarab_ll independently of the shim.
+
+## Build gotchas
+- `CMakeLists.txt` `scarab_dirs` includes `prefetcher/champsim` + `.../wrappers` (csenv excluded).
+- Stale `pin/pin_exec/obj-intel64/pin_exec.d` can reference a removed `.stat.def` after deleting a
+  prefetcher → "No rule to make target"; `rm -rf` that obj dir.

--- a/src/prefetcher/champsim/champsim_shim.cc
+++ b/src/prefetcher/champsim/champsim_shim.cc
@@ -1,0 +1,88 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/***************************************************************************************
+ * File         : prefetcher/champsim/champsim_shim.cc
+ * Description  : Implementation of the ChampSim shim routing/glue. Translates a
+ *                ChampSim prefetch_line() byte address into a Scarab cmp line index
+ *                and enqueues it at the right cache level. Owns the fake ChampSim
+ *                globals warmup_complete[] / current_core_cycle[].
+ ***************************************************************************************/
+
+#include "prefetcher/champsim/champsim_shim.h"
+
+/* Fake ChampSim globals the vendor sources reference (sized to NUM_CPUS). */
+#include "prefetcher/champsim/csenv/champsim.h"
+#include "prefetcher/champsim/csenv/ooo_cpu.h"
+
+extern "C" {
+#include "globals/assert.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "core.param.h"
+#include "general.param.h"
+#include "memory/memory.param.h"
+
+#include "prefetcher/pref_common.h"
+
+#include "statistics.h"
+}
+
+/* Definitions of the fake ChampSim globals declared extern in the csenv headers. */
+uint8_t warmup_complete[NUM_CPUS] = {0};
+uint64_t current_core_cycle[NUM_CPUS] = {0};
+OOO_CPU ooo_cpu[NUM_CPUS] = {};
+
+namespace champsim {
+
+uint64_t strip_proc(uint64_t cmp_addr) {
+  return cmp_addr & ((1ULL << 58) - 1ULL);
+}
+
+void init_globals() {
+  /* The shim fakes a fixed compile-time NUM_CPUS; refuse to run silently wrong
+   * if Scarab has more cores than that (vendor per-core arrays would overflow). */
+  ASSERTM(0, NUM_CORES <= (uns)NUM_CPUS,
+          "champsim shim built for NUM_CPUS=%d but NUM_CORES=%d; bump NUM_CPUS in "
+          "prefetcher/champsim/csenv/champsim.h\n",
+          (int)NUM_CPUS, (int)NUM_CORES);
+  for (int i = 0; i < NUM_CPUS; i++) {
+    warmup_complete[i] = 1; /* treat as past warmup from the start */
+    current_core_cycle[i] = 0;
+  }
+}
+
+void tick(uint32_t proc_id) {
+  if ((int)proc_id < NUM_CPUS) {
+    warmup_complete[proc_id] = 1;
+    current_core_cycle[proc_id] = (uint64_t)cycle_count;
+    /* Map ChampSim's per-core retired-instruction count to Scarab's inst_count[]
+     * (sim.c: "retired per core"). Used by IPCP-L1 for its MPKI throttle. */
+    ooo_cpu[proc_id].num_retired = inst_count ? (uint64_t)inst_count[proc_id] : 0;
+    ooo_cpu[proc_id].warmup_instructions = 0;
+  }
+}
+
+int shim_issue(Level level, uint32_t proc_id, int hwp_id, uint64_t pf_byte_addr, int stat_issued, int stat_qfull) {
+  uint64_t byte = strip_proc(pf_byte_addr);
+  Addr cmp = convert_to_cmp_addr((uns8)proc_id, (Addr)byte);
+  Addr line_index = cmp >> LOG2(DCACHE_LINE_SIZE);
+
+  HWP_Type dest = level == Level::DCACHE ? PREF_TO_DCACHE : level == Level::UMLC ? PREF_TO_UMLC : PREF_TO_UL1;
+  Flag ok = pref_addto_dest_req_queue((uns8)proc_id, dest, line_index, (uns8)hwp_id);
+  if (ok) {
+    if (stat_issued >= 0)
+      STAT_EVENT(proc_id, stat_issued);
+    return 1;
+  }
+  if (stat_qfull >= 0)
+    STAT_EVENT(proc_id, stat_qfull);
+  return 0;
+}
+
+void shim_stat(uint32_t proc_id, int stat_id) {
+  if (stat_id >= 0)
+    STAT_EVENT(proc_id, stat_id);
+}
+
+}  // namespace champsim

--- a/src/prefetcher/champsim/champsim_shim.h
+++ b/src/prefetcher/champsim/champsim_shim.h
@@ -1,0 +1,73 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/***************************************************************************************
+ * File         : prefetcher/champsim/champsim_shim.h
+ * Description  : Scarab-side core of the universal ChampSim prefetcher compatibility
+ *                shim. Provides the routing/address glue that the per-prefetcher
+ *                wrapper's fake CACHE object delegates to. See README in this dir.
+ *
+ *                MUST be included at GLOBAL scope (never inside a wrapper namespace):
+ *                it declares `namespace champsim`, and the per-wrapper csenv/cache.h
+ *                relies on that being the single global ::champsim.
+ ***************************************************************************************/
+#ifndef __CHAMPSIM_SHIM_H__
+#define __CHAMPSIM_SHIM_H__
+
+#include <cstdint>
+
+namespace champsim {
+
+/* Scarab destination cache level a shim instance issues prefetches into.
+ * Mirrors the framework's HWP_Type; a wrapper sets it from its instance's
+ * DEST_* token in the pref_{dcache,mlc,l1}_prefetchers list. */
+enum class Level {
+  DCACHE = 0,
+  UMLC = 1,
+  UL1 = 2
+};
+
+/* Map a ChampSim fill level (FILL_L1=1, FILL_L2=2, FILL_LLC=4) onto the Scarab
+ * cache level it should land in. Lets a multi-fill-level prefetcher (e.g. MLOP)
+ * issue to any level via the vendor's prefetch_line(fill_level) argument, instead
+ * of being collapsed onto one fixed level. Unknown values default to UMLC (L2). */
+inline Level level_from_fill(int fill_level) {
+  switch (fill_level) {
+    case 1:
+      return Level::DCACHE; /* FILL_L1  -> L1D  */
+    case 2:
+      return Level::UMLC; /* FILL_L2  -> L2   */
+    case 4:
+      return Level::UL1; /* FILL_LLC -> LLC  */
+    default:
+      return Level::UMLC;
+  }
+}
+
+/* Issue a prefetch for ChampSim byte address `pf_byte_addr` (proc bits already
+ * absent or ignored) on behalf of core `proc_id` at the given Scarab level.
+ * Converts byte addr -> Scarab cmp line index and routes through the framework's
+ * pref_addto_dest_req_queue. Returns 1 if queued, 0 if the queue was full.
+ * Increments stat id `stat_issued` (on success) or `stat_qfull` (on full);
+ * pass a negative id to skip the stat. */
+int shim_issue(Level level, uint32_t proc_id, int hwp_id, uint64_t pf_byte_addr, int stat_issued, int stat_qfull);
+
+/* Fire Scarab stat id `stat_id` for core `proc_id`, or no-op if `stat_id` < 0.
+ * Universal hook so any shim component (cache.h's note_pref_hit/note_pref_fill,
+ * etc.) can surface an internal feedback event as a stat WITHOUT including the C
+ * statistics.h inside a wrapper namespace. Each import opts in by setting the
+ * matching _stat_* id on its fake CACHE; imports that don't leave it at -1. */
+void shim_stat(uint32_t proc_id, int stat_id);
+
+/* Initialize the fake ChampSim globals (warmup_complete[]/current_core_cycle[]).
+ * Idempotent; safe to call from each prefetcher's init. Aborts if Scarab is
+ * configured with more cores than the shim's fake NUM_CPUS (see csenv/champsim.h). */
+void init_globals();
+
+/* Refresh fake ChampSim per-core globals for `proc_id` (current cycle, warmup). */
+void tick(uint32_t proc_id);
+
+/* Strip Scarab proc-id bits (>=58) from a cmp address, yielding a clean byte addr. */
+uint64_t strip_proc(uint64_t cmp_addr);
+
+}  // namespace champsim
+
+#endif  // __CHAMPSIM_SHIM_H__

--- a/src/prefetcher/champsim/csenv/.clang-format
+++ b/src/prefetcher/champsim/csenv/.clang-format
@@ -1,0 +1,8 @@
+# Vendored ChampSim prefetcher sources (*.inc) and the fake-environment headers
+# that wrap them are kept BYTE-IDENTICAL to upstream — the shim's whole premise is
+# dropping in UNMODIFIED vendor code (diff vs the original ChampSim artifact is
+# empty). Disable clang-format for this directory so the formatter and the CI
+# clang-format-diff check leave these files alone. The shim's own code (one level
+# up: champsim_shim.*, wrappers/, pref_champsim.h) is still formatted normally.
+DisableFormat: true
+SortIncludes: false

--- a/src/prefetcher/champsim/csenv/cache.h
+++ b/src/prefetcher/champsim/csenv/cache.h
@@ -1,0 +1,188 @@
+/* Universal ChampSim shim: fake of ChampSim's inc/cache.h.
+ *
+ * This header is included by each VENDOR prefetcher source via its bare
+ * `#include "cache.h"`, which the compiler resolves to THIS file via
+ * current-file-directory lookup (the vendor .inc lives in this same csenv/ dir).
+ * Because the vendor source is wrapped in `namespace cs_<name> { ... }`, this
+ * CACHE class becomes `cs_<name>::CACHE` — a DISTINCT class per prefetcher, so
+ * `CACHE::l2c_prefetcher_operate` definitions in different vendor files never
+ * collide. (champsim.h / memory_class.h / champsim_shim.h are pre-included at
+ * GLOBAL scope by the wrapper, so their include guards make the includes below
+ * no-ops here — keeping NUM_CPUS, FILL_*, and ::champsim global.)
+ */
+#ifndef CHAMPSIM_COMPAT_CACHE_H
+#define CHAMPSIM_COMPAT_CACHE_H
+
+#include "champsim.h"
+#include "memory_class.h"
+#include "prefetcher/champsim/champsim_shim.h"
+
+/* Minimal per-block metadata a prefetcher may inspect (e.g. MLOP reads
+ * block[set][way].prefetch to detect a prefetch hit). */
+struct CS_BLOCK {
+  uint8_t prefetch;
+  uint8_t valid;
+};
+
+/* Minimal queue model for bandwidth-aware prefetchers (PQ.occupancy/SIZE,
+ * MSHR.occupancy/SIZE). Defaults make "queue never full" so prefetchers that
+ * gate on occupancy behave like the hand-ports (no PQ throttle). */
+struct CS_QUEUE {
+  uint32_t occupancy;
+  uint32_t SIZE;
+};
+
+class CACHE {
+ public:
+  /* ---- ChampSim-visible members vendor sources touch ---- */
+  uint32_t cpu;
+  const char* NAME;
+  uint32_t NUM_SET;
+  uint32_t NUM_WAY;
+  CS_QUEUE PQ;
+  CS_QUEUE MSHR;
+
+  /* ---- Scarab-side glue (not part of the ChampSim contract) ---- */
+  champsim::Level _level;   /* destination level (instance's DEST_* token) when !_route_by_fill */
+  bool _route_by_fill;      /* if true, route each prefetch by its fill_level arg
+                               (FILL_L1->DL0, FILL_L2->UMLC, FILL_LLC->UL1) so a
+                               multi-fill-level prefetcher hits all levels as designed */
+  bool _dedup_per_op;       /* if true, collapse duplicate blocks issued within one
+                               operate() to a single prefetch (e.g. MLOP re-issues a
+                               block when upgrading FILL_L2->FILL_L1; on a single
+                               Scarab level those are redundant). */
+  std::unordered_set<uint64_t> _op_issued;  /* blocks issued in the current operate */
+  /* Inter-level metadata channel: when set, every prefetch_line() this component
+   * issues also forwards (pf_addr, ip, metadata) downstream. Used to feed a
+   * cooperating next-level component (e.g. IPCP L1 -> L2), reproducing ChampSim's
+   * pf_metadata handoff where an L1 prefetch arriving at L2 triggers l2c operate. */
+  std::function<void(uint64_t /*pf_addr*/, uint64_t /*ip*/, uint32_t /*metadata*/)> _downstream_op;
+  int _hwp_id;
+  int _stat_issued;
+  int _stat_qfull;
+  /* Optional observability for the accuracy feedback loop (acc = useful/filled).
+   * Set by a wrapper to its prefetcher's stat ids; -1 = don't count. Lets us read
+   * the otherwise-internal pref_useful/pref_filled counters from memory.stat. */
+  int _stat_useful;
+  int _stat_fill;
+  uint8_t _cur_pref_hit;   /* set by wrapper before each operate; surfaced via block[][].prefetch */
+  CS_BLOCK _blk;           /* the single fake block get_set/get_way always resolve to */
+
+  /* Prefetch-accuracy accounting some prefetchers (IPCP-L1) read for degree
+   * adaptation. ChampSim's cache.cc updates these on fill/hit/MSHR-merge; the shim
+   * approximates that by attributing each successfully issued prefetch to a class
+   * (pf_metadata bits 8-11, ChampSim convention), then bumping pref_filled[class]
+   * at FILL (note_pref_fill, from the umlc_cache_fill hook) and pref_useful[class]
+   * on a demand hit to a prefetched line (note_pref_hit, from the pref-hit hooks).
+   * This restores IPCP's accuracy-based degree throttle; without it acc sticks at
+   * the 60% default and IPCP over-prefetches on irregular workloads. */
+  uint64_t pref_filled[NUM_CPUS][6] = {};
+  uint64_t pref_useful[NUM_CPUS][6] = {};
+  uint64_t pref_late[NUM_CPUS][6] = {};
+  uint64_t pf_fill = 0;
+  uint64_t pf_useful = 0;
+  /* block-addr -> class table so a later demand pref-hit can be attributed to the
+   * class that issued it (Scarab cache lines don't carry pf_metadata). Direct-mapped;
+   * collisions just misattribute a hit between classes (benign for the ratio). */
+  static const uint32_t CLASS_TBL_MASK = (1u << 16) - 1u;
+  uint8_t _pf_class_tbl[1u << 16] = {};
+  void note_pref_hit(uint64_t pf_addr) {
+    uint8_t cls = _pf_class_tbl[(pf_addr >> 6) & CLASS_TBL_MASK];
+    if (cls < 6)
+      pref_useful[cpu][cls]++;
+    champsim::shim_stat(cpu, _stat_useful);
+  }
+  /* A prefetch actually filled the cache: count it under its issuing class. acc =
+   * useful/filled then reflects true prefetch accuracy (fills that got demand-hit). */
+  void note_pref_fill(uint64_t fill_addr) {
+    uint8_t cls = _pf_class_tbl[(fill_addr >> 6) & CLASS_TBL_MASK];
+    if (cls < 6)
+      pref_filled[cpu][cls]++;
+    champsim::shim_stat(cpu, _stat_fill);
+  }
+
+  CACHE()
+      : cpu(0), NAME("champsim"), NUM_SET(1024), NUM_WAY(16),
+        PQ{0u, (1u << 20)}, MSHR{0u, (1u << 20)},
+        _level(champsim::Level::UMLC), _route_by_fill(false), _dedup_per_op(false),
+        _hwp_id(0), _stat_issued(-1), _stat_qfull(-1),
+        _stat_useful(-1), _stat_fill(-1), _cur_pref_hit(0) {
+    _blk.prefetch = 0;
+    _blk.valid = 1;
+    block.b = &_blk;
+  }
+
+  /* ---- ChampSim callbacks INTO the cache ---- */
+  int prefetch_line(uint64_t ip, uint64_t /*base_addr*/, uint64_t pf_addr,
+                    int fill_level, uint32_t metadata) {
+    if (_dedup_per_op) {
+      uint64_t blk = (pf_addr & ((1ULL << 58) - 1ULL)) >> 6;  /* LOG2_BLOCK_SIZE */
+      if (!_op_issued.insert(blk).second)
+        return 1;  /* already issued this operate; suppress redundant re-issue */
+    }
+    champsim::Level tgt = _route_by_fill ? champsim::level_from_fill(fill_level) : _level;
+    int ok = champsim::shim_issue(tgt, cpu, _hwp_id, pf_addr, _stat_issued, _stat_qfull);
+    if (ok) {
+      /* Remember block->class (from pf_metadata bits 8-11) so the eventual fill and
+       * demand pref-hit can be attributed to the issuing class. pref_filled is bumped
+       * at FILL (note_pref_fill), not here -- counting every issue overcounts (lookahead
+       * re-issues, drops, redundant hits), deflating acc and over-throttling. */
+      _pf_class_tbl[(pf_addr >> 6) & CLASS_TBL_MASK] = (uint8_t)((metadata >> 8) & 0x7u);
+    }
+    /* Feed the cooperating downstream component this prefetch's metadata (ChampSim:
+     * an L1-issued prefetch reaching L2 triggers l2c_prefetcher_operate). */
+    if (_downstream_op)
+      _downstream_op(pf_addr, ip, metadata);
+    return ok;
+  }
+  void begin_operate() { if (_dedup_per_op) _op_issued.clear(); }
+  uint32_t get_occupancy(uint8_t /*queue_type*/, uint64_t /*addr*/) { return 0; }
+  uint32_t get_size(uint8_t /*queue_type*/, uint64_t /*addr*/) { return PQ.SIZE; }
+
+  /* Tag-array access faked to a single block reflecting the current access's
+   * prefetch-hit-ness (Scarab tells us which hook fired). get_set/get_way
+   * always resolve to that one block. */
+  uint32_t get_set(uint64_t /*addr*/) { return 0; }
+  uint32_t get_way(uint64_t /*addr*/, uint32_t /*set*/) { return 0; }
+
+  struct BlockRow {
+    CS_BLOCK* b;
+    CS_BLOCK& operator[](uint32_t) { return *b; }
+  };
+  struct BlockArr {
+    CS_BLOCK* b;
+    BlockRow operator[](uint32_t) { return BlockRow{b}; }
+  } block;   /* vendor accesses as block[set][way] */
+
+  /* ---- Prefetcher module entry points (vendor defines whichever family it uses) ---- */
+  /* L2C family */
+  void l2c_prefetcher_initialize();
+  uint32_t l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit,
+                                  uint8_t type, uint32_t metadata_in,
+                                  uint8_t critical_ip_flag);
+  uint32_t l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way,
+                                     uint8_t prefetch, uint64_t evicted_addr,
+                                     uint32_t metadata_in);
+  void l2c_prefetcher_final_stats();
+
+  /* L1D family */
+  void l1d_prefetcher_initialize();
+  void l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit,
+                              uint8_t type, uint8_t critical_ip_flag);
+  void l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set,
+                                 uint32_t way, uint8_t prefetch,
+                                 uint64_t v_evicted_addr, uint64_t evicted_addr,
+                                 uint32_t metadata_in);
+  void l1d_prefetcher_final_stats();
+
+  /* LLC family */
+  void llc_prefetcher_initialize();
+  uint32_t llc_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit,
+                                  uint8_t type, uint32_t metadata_in);
+  uint32_t llc_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way,
+                                     uint8_t prefetch, uint64_t evicted_addr,
+                                     uint32_t metadata_in);
+  void llc_prefetcher_final_stats();
+};
+
+#endif  // CHAMPSIM_COMPAT_CACHE_H

--- a/src/prefetcher/champsim/csenv/champsim.h
+++ b/src/prefetcher/champsim/csenv/champsim.h
@@ -1,0 +1,57 @@
+/* Universal ChampSim shim: minimal fake of ChampSim's inc/champsim.h.
+ * Provides only the constants/globals that DPC3 prefetcher sources reference.
+ * Included at GLOBAL scope by each wrapper (and by champsim_shim.cc) so the
+ * NUM_CPUS macro, FILL_* constants, and warmup_complete[]/current_core_cycle[]
+ * externs live in the global namespace, not inside a wrapper's namespace. */
+#ifndef CHAMPSIM_H
+#define CHAMPSIM_H
+
+#include <cstdint>
+#include <cassert>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <vector>
+#include <deque>
+#include <queue>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <functional>
+
+using namespace std;
+
+/* CPU: the shim emulates a single-core ChampSim (matches Scarab single-core
+ * experiments and the hand-port behaviour, incl. IPCP's NUM_CPUS==1 degree=3
+ * branch). Bump this (and rebuild) to support multi-core; init_globals() asserts
+ * NUM_CORES <= NUM_CPUS. */
+#define NUM_CPUS 1
+
+#define PAGE_SIZE 4096
+#define LOG2_PAGE_SIZE 12
+#define BLOCK_SIZE 64
+#define LOG2_BLOCK_SIZE 6
+
+/* ChampSim cache sizing constants some prefetchers use for table sizing. */
+#define L2C_MSHR_SIZE 32
+
+/* Fill levels (bitmask form, as in ChampSim). The shim ignores these for queue
+ * selection — routing is by the wrapper's registered Scarab Level. */
+#define FILL_L1   1
+#define FILL_L2   2
+#define FILL_LLC  4
+#define FILL_DRAM 16
+
+/* Owned/defined in champsim_shim.cc; updated via champsim::tick()/init_globals(). */
+extern uint8_t  warmup_complete[NUM_CPUS];
+
+/* ChampSim's debug-print macro; compiled out in the shim. */
+#ifndef DP
+#define DP(x)
+#endif
+extern uint64_t current_core_cycle[NUM_CPUS];
+
+#endif  // CHAMPSIM_H

--- a/src/prefetcher/champsim/csenv/ip_stride.l2c.inc
+++ b/src/prefetcher/champsim/csenv/ip_stride.l2c.inc
@@ -1,0 +1,149 @@
+//
+// From Data Prefetching Championship Simulator 2
+// Seth Pugsley, seth.h.pugsley@intel.com
+//
+
+/*
+
+  This file describes an Instruction Pointer-based (Program Counter-based) stride prefetcher.  
+  The prefetcher detects stride patterns coming from the same IP, and then 
+  prefetches additional cache lines.
+
+  Prefetches are issued into the L2 or LLC depending on L2 MSHR occupancy.
+
+ */
+
+#include "cache.h"
+
+#define IP_TRACKER_COUNT 1024
+#define PREFETCH_DEGREE 3
+
+class IP_TRACKER {
+  public:
+    // the IP we're tracking
+    uint64_t ip;
+
+    // the last address accessed by this IP
+    uint64_t last_cl_addr;
+
+    // the stride between the last two addresses accessed by this IP
+    int64_t last_stride;
+
+    // use LRU to evict old IP trackers
+    uint32_t lru;
+
+    IP_TRACKER () {
+        ip = 0;
+        last_cl_addr = 0;
+        last_stride = 0;
+        lru = 0;
+    };
+};
+
+IP_TRACKER trackers[IP_TRACKER_COUNT];
+
+void CACHE::l2c_prefetcher_initialize() 
+{
+    cout << "CPU " << cpu << " L2C IP-based stride prefetcher" << endl;
+    for (int i=0; i<IP_TRACKER_COUNT; i++)
+        trackers[i].lru = i;
+}
+
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in, uint8_t critical_ip_flag)
+{
+    // check for a tracker hit
+    uint64_t cl_addr = addr >> LOG2_BLOCK_SIZE;
+
+    int index = -1;
+    for (index=0; index<IP_TRACKER_COUNT; index++) {
+        if (trackers[index].ip == ip)
+            break;
+    }
+
+    // this is a new IP that doesn't have a tracker yet, so allocate one
+    if (index == IP_TRACKER_COUNT) {
+
+        for (index=0; index<IP_TRACKER_COUNT; index++) {
+            if (trackers[index].lru == (IP_TRACKER_COUNT-1))
+                break;
+        }
+
+        trackers[index].ip = ip;
+        trackers[index].last_cl_addr = cl_addr;
+        trackers[index].last_stride = 0;
+
+        //cout << "[IP_STRIDE] MISS index: " << index << " lru: " << trackers[index].lru << " ip: " << hex << ip << " cl_addr: " << cl_addr << dec << endl;
+
+        for (int i=0; i<IP_TRACKER_COUNT; i++) {
+            if (trackers[i].lru < trackers[index].lru)
+                trackers[i].lru++;
+        }
+        trackers[index].lru = 0;
+
+        return metadata_in;
+    }
+
+    // sanity check
+    // at this point we should know a matching tracker index
+    if (index == -1)
+        assert(0);
+
+    // calculate the stride between the current address and the last address
+    // this bit appears overly complicated because we're calculating
+    // differences between unsigned address variables
+    int64_t stride = 0;
+    if (cl_addr > trackers[index].last_cl_addr)
+        stride = cl_addr - trackers[index].last_cl_addr;
+    else {
+        stride = trackers[index].last_cl_addr - cl_addr;
+        stride *= -1;
+    }
+
+    //cout << "[IP_STRIDE] HIT  index: " << index << " lru: " << trackers[index].lru << " ip: " << hex << ip << " cl_addr: " << cl_addr << dec << " stride: " << stride << endl;
+
+    // don't do anything if we somehow saw the same address twice in a row
+    if (stride == 0)
+        return metadata_in;
+
+    // only do any prefetching if there's a pattern of seeing the same
+    // stride more than once
+    if (stride == trackers[index].last_stride) {
+
+        // do some prefetching
+        for (int i=0; i<PREFETCH_DEGREE; i++) {
+            uint64_t pf_address = (cl_addr + (stride*(i+1))) << LOG2_BLOCK_SIZE;
+
+            // only issue a prefetch if the prefetch address is in the same 4 KB page 
+            // as the current demand access address
+            if ((pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE))
+                break;
+
+            // check the MSHR occupancy to decide if we're going to prefetch to the L2 or LLC
+            if (MSHR.occupancy < (MSHR.SIZE>>1))
+	      prefetch_line(ip, addr, pf_address, FILL_L2, 0);
+            else
+	      prefetch_line(ip, addr, pf_address, FILL_LLC, 0);
+        }
+    }
+
+    trackers[index].last_cl_addr = cl_addr;
+    trackers[index].last_stride = stride;
+
+    for (int i=0; i<IP_TRACKER_COUNT; i++) {
+        if (trackers[i].lru < trackers[index].lru)
+            trackers[i].lru++;
+    }
+    trackers[index].lru = 0;
+
+    return metadata_in;
+}
+
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t match, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+  return metadata_in;
+}
+
+void CACHE::l2c_prefetcher_final_stats()
+{
+    cout << "CPU " << cpu << " L2C PC-based stride prefetcher final stats" << endl;
+}

--- a/src/prefetcher/champsim/csenv/ipcp_isca2020.l1d.inc
+++ b/src/prefetcher/champsim/csenv/ipcp_isca2020.l1d.inc
@@ -1,0 +1,1045 @@
+/*************************************************************************************************************************
+Authors: 
+Samuel Pakalapati - samuelpakalapati@gmail.com
+Biswabandan Panda - biswap@cse.iitk.ac.in
+Nilay Shah - nilays@iitk.ac.in
+Neelu Shivprakash kalani - neeluk@cse.iitk.ac.in 
+**************************************************************************************************************************/
+
+/*************************************************************************************************************************
+Source code of "Bouquet of Instruction Pointers: Instruction Pointer Classifier-based Spatial Hardware Prefetching" 
+appeared (to appear) in ISCA 2020: https://www.iscaconf.org/isca2020/program/. The paper is available at 
+https://www.cse.iitk.ac.in/users/biswap/IPCP_ISCA20.pdf. The source code can be used with the ChampSim simulator 
+https://github.com/ChampSim . Note that the authors have used a modified ChampSim that supports detailed virtual 
+memory sub-system. Performance numbers may increase/decrease marginally
+based on the virtual memory-subsystem support. Also for PIPT L1-D caches, this code may demand 1 to 1.5KB additional 
+storage for various hardware tables.     
+**************************************************************************************************************************/
+
+#include "ooo_cpu.h"
+#include "cache.h"
+#include "ipcp_table_sizes.h"
+#include <vector>
+
+/**************************************************************************************************************************
+Note that variables uint64_t pref_useful[NUM_CPUS][6], pref_filled[NUM_CPUS][6], pref_late[NUM_CPUS][6]; are to be declared 
+as members of the CACHE class in inc/cache.h and modified in src/cache.cc where the second level index denotes the IPCP prefetch 
+class type for each variable which can be extracted through pf_metadata. A prefetch is considered in pref_useful when a cache 
+blocks gets a hit and its prefetch bit is set. Whenever a cache block is filled (in handle_fill) and its type is prefetch, 
+pref_fill is incremented. The pref_late variable is modified whenever a demand request merges with a prefetch request or 
+vice versa in the cache's MSHR as, if the prefetch would've been on time, the demand request would've hit in the cache.
+****************************************************************************************************************************/ 
+
+//#define CRITICAL_IP_PREF
+
+#define DO_PREF
+#define NUM_BLOOM_ENTRIES 4096				    // For book-keeping purposes
+#define NUM_IP_TAG_BITS 9 	
+#define NUM_PAGE_TAG_BITS 2
+#define S_TYPE 1                                            // stream
+#define CS_TYPE 2                                           // constant stride
+#define CPLX_TYPE 3                                         // complex stride
+#define NL_TYPE 4                                           // next line
+#define CPLX_DIST 0                                          
+#define RR_TAG_MASK 0xFFF				    // 12 bits of prefetch line address are stored in recent request filter
+#define NUM_OF_RR_ENTRIES 32
+#define MAX_POS_NEG_COUNT 64				    // 6-bit saturating counter
+#define NUM_OF_LINES_IN_REGION 32			    // 32 cache lines in 2KB region
+#define REGION_OFFSET_MASK 0x1F				    // 5-bit offset for 2KB region
+
+// #define SIG_DEBUG_PRINT				    // Uncomment to turn on Debug Print
+#ifdef SIG_DEBUG_PRINT
+#define SIG_DP(x) x
+#else
+#define SIG_DP(x)
+#endif
+
+class IP_TABLE_L1 {
+  public:
+    uint64_t ip_tag;					    
+    uint64_t last_vpage;                                    // last page seen by IP 
+    uint64_t last_line_offset;                              // last cl offset in the 4KB page 
+    int64_t last_stride;                                    // last stride observed 
+    uint16_t ip_valid;					    // valid bit
+    int conf;                                               // CS confidence 
+    uint16_t signature;                                     // CPLX signature 
+    uint16_t str_dir;                                       // stream direction 
+    uint16_t str_valid;                                     // stream valid 
+    uint16_t pref_type;                                     // pref type or class for book-keeping purposes.
+
+    IP_TABLE_L1 () {
+        ip_tag = 0;
+        last_vpage = 0;
+        last_line_offset = 0;
+        last_stride = 0;
+        ip_valid = 0;
+        signature = 0;
+        conf = 0;
+        str_dir = 0;
+        str_valid = 0;
+        pref_type = 0;
+    };
+};
+
+/*	IP TABLE STORAGE OVERHEAD: 288 Bytes
+
+	Single Entry:
+
+	FIELD					STORAGE (bits)
+	
+	IP tag					9 
+	last page				2
+	last line offset			6
+	last stride				7 	(6 bits stride + 1 sign bit)
+	IP valid				1
+	confidence				2
+	signature				7
+	stream direction			1	1
+	stream valid				1
+	
+	Total 					36
+
+	Full Table Storage Overhead: 
+
+	64 entries * 36 bits = 2304 bits = 288 Bytes
+
+	NOTE: The field prefetch class is used for book-keeping purposes. 
+
+*/
+
+
+class CONST_STRIDE_PRED_TABLE {
+public:
+    int stride;
+    int conf;
+
+    CONST_STRIDE_PRED_TABLE () {
+        stride = 0;
+        conf = 0;
+    };        
+};
+
+/*	CONSTANT STRIDE STORAGE OVERHEAD: 144 Bytes
+
+	Single Entry:
+
+	FIELD					STORAGE (bits)
+	
+	stride					7	(6 bits stride + 1 sign bit)
+	confidence 				2
+
+	Total					9
+
+	Full Table Storage Overhead:
+	
+	128 entries * 9 bits = 1152 bits = 144 Bytes
+
+*/
+
+/* This class is for bookkeeping purposes only. */
+class STAT_COLLECT {
+  public:
+    uint64_t useful;                                    
+    uint64_t filled;                                    
+    uint64_t misses;	
+    uint64_t polluted_misses;  	                            
+
+    uint8_t bl_filled[NUM_BLOOM_ENTRIES];		
+    uint8_t bl_request[NUM_BLOOM_ENTRIES];		
+
+    STAT_COLLECT () {
+        useful = 0;
+        filled = 0;
+        misses = 0;
+        polluted_misses = 0;
+
+        for(int i=0; i<NUM_BLOOM_ENTRIES; i++){
+            bl_filled[i] = 0;
+            bl_request[i] = 0;
+        }
+    };
+};
+
+class REGION_STREAM_TABLE {
+    public:
+        uint64_t region_id;		
+        uint64_t tentative_dense;			// tentative dense bit
+        uint64_t trained_dense;				// trained dense bit
+        uint64_t pos_neg_count;				// positive/negative stream counter
+        uint64_t dir;					// direction of stream - 1 for +ve and 0 for -ve
+        uint64_t lru;					// lru for replacement
+        uint8_t line_access[NUM_OF_LINES_IN_REGION];	// bit vector to store which lines in the 2KB region have been accessed
+        REGION_STREAM_TABLE () {
+            region_id=0;
+            tentative_dense=0;
+            trained_dense=0;
+            pos_neg_count=MAX_POS_NEG_COUNT/2;
+            dir=0;
+            lru=0;
+            for(int i=0; i < NUM_OF_LINES_IN_REGION; i++)
+                line_access[i]=0;
+        };
+};
+
+/*	REGION STREAM TABLE STORAGE OVERHEAD:
+
+	Single Entry: 
+
+	FIELD					STORAGE (bits)
+
+	region id				3
+	tentative dense				1
+	trained dense				1
+	positive/negative count			6
+	direction				1
+	lru 					3
+	bit vector line access			32	(for 2KB region)
+
+	Total					47
+
+	Full Table Storage Overhead:
+
+	8 entries * 47 bits = 376 bits = 47 Bytes
+
+*/
+
+uint64_t ip_table_write_accesses = 0, ip_table_read_accesses = 0, rstable_write_accesses = 0, rstable_read_accesses = 0, cspt_write_accesses = 0, cspt_read_accesses = 0, rrfilter_read_accesses = 0, rrfilter_write_accesses = 0;
+uint64_t ip_table_tag_write_accesses = 0, ip_table_tag_read_accesses = 0, rstable_tag_write_accesses = 0, rstable_tag_read_accesses = 0, rrfilter_tag_write_accesses = 0, rrfilter_tag_read_accesses = 0;
+uint8_t warmup_flag_l1 = 0;
+
+REGION_STREAM_TABLE rstable [NUM_CPUS][NUM_RST_ENTRIES];
+int acc_filled[NUM_CPUS][5];
+int acc_useful[NUM_CPUS][5];
+
+int acc[NUM_CPUS][5];
+int prefetch_degree[NUM_CPUS][5];
+int num_conflicts =0;
+uint64_t degree_decremented_times = 0, degree_incremented_times = 0;
+int test;
+
+uint64_t eval_buffer[NUM_CPUS][1024] = {};
+STAT_COLLECT stats[NUM_CPUS][5];     // for GS, CS, CPLX, NL and no class
+IP_TABLE_L1 trackers_l1[NUM_CPUS][NUM_IP_TABLE_L1_ENTRIES];
+CONST_STRIDE_PRED_TABLE CSPT_l1[NUM_CPUS][NUM_CSPT_ENTRIES];
+
+vector<uint64_t> recent_request_filter;		// to filter redundant prefetch requests 
+
+/* 	RECENT REQUEST FILTER STORAGE OVERHEAD: 48 Bytes
+
+	FIELD					STORAGE (bits)
+	
+	Tag					12
+
+	Total Storage Overhead:
+
+	32 entries * 12 bits = 384 bits = 48 Bytes
+
+*/
+
+uint64_t prev_cpu_cycle[NUM_CPUS];
+uint64_t num_misses[NUM_CPUS];
+float mpki[NUM_CPUS] = {0};
+int spec_nl[NUM_CPUS] = {0}, flag_nl[NUM_CPUS] = {0};
+uint64_t num_access[NUM_CPUS];
+
+int meta_counter[NUM_CPUS][4] = {0};                                                  // for book-keeping
+int total_count[NUM_CPUS] = {0};                                                  // for book-keeping
+
+
+/* update_sig_l1: 7 bit signature is updated by performing a left-shift of 1 bit on the old signature and xoring the outcome with the delta*/
+
+uint16_t update_sig_l1(uint16_t old_sig, int delta){
+    	uint16_t new_sig = 0;
+    	int sig_delta = 0;
+
+    	// 7-bit sign magnitude form, since we need to track deltas from +63 to -63
+    	sig_delta = (delta < 0) ? (((-1) * delta) + (1 << 6)) : delta;
+    	new_sig = ((old_sig << 1) ^ sig_delta) & ((1 << NUM_SIG_BITS)-1);                     
+
+    	return new_sig;
+}
+
+/* encode_metadata: The stride, prefetch class type and speculative nl fields are encoded in the metadata. */
+
+uint32_t encode_metadata(int stride, uint16_t type, int spec_nl){
+	uint32_t metadata = 0;
+
+	// first encode stride in the last 8 bits of the metadata
+	if(stride > 0)
+    		metadata = stride;
+	else
+    		metadata = ((-1*stride) | 0b1000000);
+
+	// encode the type of IP in the next 4 bits 			 
+	metadata = metadata | (type << 8);
+
+	// encode the speculative NL bit in the next 1 bit
+	metadata = metadata | (spec_nl << 12);
+
+	return metadata;
+}
+
+/*If the actual stride and predicted stride are equal, then the confidence counter is incremented. */
+
+int update_conf(int stride, int pred_stride, int conf){
+#define MAX_CONF 3
+    if(stride == pred_stride){             // use 2-bit saturating counter for confidence
+        conf++;
+        if(conf > MAX_CONF)
+            conf = 3;
+    } else {
+        conf--;
+        if(conf < 0)
+            conf = 0;
+    }
+
+    return conf;
+}
+
+
+uint64_t hash_bloom(uint64_t addr){
+    uint64_t first_half, sec_half;
+    first_half = addr & 0xFFF;
+    sec_half = (addr >> 12) & 0xFFF;
+    if((first_half ^ sec_half) >= 4096)
+        assert(0);
+    return ((first_half ^ sec_half) & 0xFFF);
+}
+
+uint64_t hash_page(uint64_t addr){
+    uint64_t hash;
+    while(addr != 0){
+        hash = hash ^ addr;
+        addr = addr >> 6;
+    }
+
+    return hash & ((1 << NUM_PAGE_TAG_BITS)-1);
+}
+
+
+void stat_col_L1(uint64_t addr, uint8_t cache_hit, uint8_t cpu, uint64_t ip){
+    uint64_t index = hash_bloom(addr);
+    int ip_index = ip & ((1 << NUM_IP_INDEX_BITS)-1);
+    uint16_t ip_tag = (ip >> NUM_IP_INDEX_BITS) & ((1 << NUM_IP_TAG_BITS)-1);
+
+
+    for(int i=0; i<5; i++){
+        if(cache_hit){
+            if(stats[cpu][i].bl_filled[index] == 1){
+                stats[cpu][i].useful++;
+                stats[cpu][i].filled++;
+                stats[cpu][i].bl_filled[index] = 0;
+            }
+        } else {
+            if(ip_tag == trackers_l1[cpu][ip_index].ip_tag){
+                if(trackers_l1[cpu][ip_index].pref_type == i)
+                    stats[cpu][i].misses++;
+                if(stats[cpu][i].bl_filled[index] == 1){
+                    stats[cpu][i].polluted_misses++;
+                    stats[cpu][i].filled++;
+                    stats[cpu][i].bl_filled[index] = 0;
+                }
+            }
+        }
+
+        if(num_misses[cpu] % 1024 == 0){
+            for(int j=0; j<NUM_BLOOM_ENTRIES; j++){
+                stats[cpu][i].filled += stats[cpu][i].bl_filled[j];
+                stats[cpu][i].bl_filled[j] = 0;
+                stats[cpu][i].bl_request[j] = 0;
+            }
+        }
+    }
+}
+
+
+void CACHE::l1d_prefetcher_initialize() 
+{
+	//Neelu: Adding a sanity check for number of sets to be a power of 2.
+                int temp_num_sets = 1;
+                for(int i = 1; i <= NUM_IP_INDEX_BITS; i++)
+                        temp_num_sets *= 2;
+
+                if(temp_num_sets != NUM_IP_TABLE_L1_ENTRIES)
+                {
+                        cout << "ERROR: --> num_sets: " << NUM_IP_TABLE_L1_ENTRIES << ", index_len: " << NUM_IP_INDEX_BITS << endl;
+                        cout << "ERROR: --> Oops: Num of sets are not 2^index_len. Kindly input cache sets and ways accordingly. <--" << endl;
+                        assert(0);
+                }
+
+	cout << "IP Table Entries: " << NUM_IP_TABLE_L1_ENTRIES << endl;
+	cout << "CSPT Entries: " << NUM_CSPT_ENTRIES << endl; 
+	cout << "RR_ENTRIES: " << NUM_OF_RR_ENTRIES << endl;
+	cout << "RST_ENTRIES: " << NUM_RST_ENTRIES << endl; 
+
+    for( int i=0; i <NUM_RST_ENTRIES; i++)
+        rstable[cpu][i].lru = i;
+    for( int i=0; i <NUM_CPUS; i++)
+    {
+        prefetch_degree[cpu][0] = 0;
+        prefetch_degree[cpu][1] = 6;
+        prefetch_degree[cpu][2] = 3;
+        prefetch_degree[cpu][3] = 3;
+        prefetch_degree[cpu][4] = 1;
+
+    }
+
+ 
+}
+
+void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint8_t critical_ip_flag)
+{
+
+	if(warmup_flag_l1 == 0 && warmup_complete[cpu])
+	{
+		ip_table_write_accesses = 0;
+		ip_table_read_accesses = 0;
+		rstable_write_accesses = 0; 
+		rstable_read_accesses = 0;
+		cspt_write_accesses = 0;
+		cspt_read_accesses = 0;
+		rrfilter_write_accesses = 0; 
+		rrfilter_read_accesses = 0;
+		ip_table_tag_write_accesses = 0;
+                ip_table_tag_read_accesses = 0;
+                rstable_tag_write_accesses = 0;
+                rstable_tag_read_accesses = 0;
+                //cspt_tag_write_accesses = 0;
+               // cspt_tag_read_accesses = 0;
+                rrfilter_tag_write_accesses = 0;
+                rrfilter_tag_read_accesses = 0;
+		num_conflicts = 0;
+		warmup_flag_l1 = 1;
+	}
+
+#ifdef CRITICAL_IP_PREF
+        if(critical_ip_flag == 0)
+                return;
+#endif
+
+    uint64_t curr_page = hash_page(addr >> LOG2_PAGE_SIZE); 	//current page 
+    uint64_t line_addr = addr >> LOG2_BLOCK_SIZE;		//cache line address
+    uint64_t line_offset = (addr >> LOG2_BLOCK_SIZE) & 0x3F; 	//cache line offset
+    uint16_t signature = 0, last_signature = 0;
+    int spec_nl_threshold = 0;
+    int num_prefs = 0;
+    uint32_t metadata=0;
+    uint16_t ip_tag = (ip >> NUM_IP_INDEX_BITS) & ((1 << NUM_IP_TAG_BITS)-1);
+    uint64_t bl_index = 0;
+
+    if(NUM_CPUS == 1){
+        spec_nl_threshold = 50; 
+    } 
+    else {                                    //tightening the mpki constraints for multi-core
+        spec_nl_threshold = 40;
+    }
+
+    // update miss counter
+    if(cache_hit == 0 && warmup_complete[cpu] == 1)
+        num_misses[cpu] += 1;
+    num_access[cpu] += 1;
+    stat_col_L1(addr, cache_hit, cpu, ip);
+    // update spec nl bit when num misses crosses certain threshold
+    if(num_misses[cpu] % 256 == 0 && cache_hit == 0){
+        mpki[cpu] = ((num_misses[cpu]*1000.0)/(ooo_cpu[cpu].num_retired - ooo_cpu[cpu].warmup_instructions));
+    
+        if(mpki[cpu] > spec_nl_threshold)
+            spec_nl[cpu] = 0;
+        else
+            spec_nl[cpu] = 1;
+
+        
+    }
+
+    //Updating prefetch degree based on accuracy
+    for(int i=0;i<5;i++)	
+    {       
+        if(pref_filled[cpu][i]%256 == 0)
+        {
+    
+            acc_useful[cpu][i]=acc_useful[cpu][i]/2.0 + (pref_useful[cpu][i] - acc_useful[cpu][i])/2.0;
+            acc_filled[cpu][i]=acc_filled[cpu][i]/2.0 + (pref_filled[cpu][i] - acc_filled[cpu][i])/2.0;
+
+            if(acc_filled[cpu][i] != 0)
+                acc[cpu][i]=100.0*acc_useful[cpu][i]/(acc_filled[cpu][i]);
+            else 
+                acc[cpu][i] = 60;
+
+            if(acc[cpu][i] > 75)
+            {
+		degree_incremented_times++;
+                prefetch_degree[cpu][i]++;
+                if(i == 1)	
+                {
+		    //For GS class, degree is incremented/decremented by 2.
+                    prefetch_degree[cpu][i]++;
+                    if(prefetch_degree[cpu][i] > 6)
+                        prefetch_degree[cpu][i] = 6; 
+                }
+                else if(prefetch_degree[cpu][i] > 3)
+                    prefetch_degree[cpu][i] = 3;
+            }
+            else if(acc[cpu][i] < 40)
+            {
+		degree_decremented_times++;
+                prefetch_degree[cpu][i]--;
+                if(i == 1)
+                    prefetch_degree[cpu][i]--;
+                if(prefetch_degree[cpu][i] < 1)
+                    prefetch_degree[cpu][i] = 1;
+            }
+
+        }
+    }
+	
+	//increment one access for tag read, it will be one+ for tag write too I guess? 
+	ip_table_tag_read_accesses++;
+	ip_table_tag_write_accesses++;
+
+
+    // calculate the index bit
+    int index = ip & ((1 << NUM_IP_INDEX_BITS)-1);
+    if(trackers_l1[cpu][index].ip_tag != ip_tag){               // new/conflict IP
+        if(trackers_l1[cpu][index].ip_valid == 0){              // if valid bit is zero, update with latest IP info
+            num_conflicts++;
+
+		//increment one write access.
+		ip_table_write_accesses++;
+
+            trackers_l1[cpu][index].ip_tag = ip_tag;
+            trackers_l1[cpu][index].last_vpage = curr_page;
+            trackers_l1[cpu][index].last_line_offset = line_offset;
+            trackers_l1[cpu][index].last_stride = 0;
+            trackers_l1[cpu][index].signature = 0;
+            trackers_l1[cpu][index].conf = 0;
+            trackers_l1[cpu][index].str_valid = 0;
+            trackers_l1[cpu][index].str_dir = 0;
+            trackers_l1[cpu][index].pref_type = 0;
+            trackers_l1[cpu][index].ip_valid = 1;
+        } 
+	else {                                                    // otherwise, reset valid bit and leave the previous IP as it is
+            trackers_l1[cpu][index].ip_valid = 0;
+        }
+
+        return;
+    }
+    else {                                                     // if same IP encountered, set valid bit
+        trackers_l1[cpu][index].ip_valid = 1;
+    }
+    
+
+	//Incrementing read and write access for IP table.
+	ip_table_write_accesses++;
+	ip_table_read_accesses++;
+
+    // calculate the stride between the current cache line offset and the last cache line offset
+    int64_t stride = 0;
+    if (line_offset > trackers_l1[cpu][index].last_line_offset)
+        stride = line_offset - trackers_l1[cpu][index].last_line_offset;
+    else {
+        stride = trackers_l1[cpu][index].last_line_offset - line_offset;
+        stride *= -1;
+    }
+
+    // don't do anything if same address is seen twice in a row
+    if (stride == 0)
+        return;
+
+    int c=0, flag = 0;
+
+	
+	//incrementing one read access for rs_table
+	//rstable_read_accesses++;
+
+
+    //Checking if IP is already classified as a part of the GS class, so that for the new region we will set the tentative (spec_dense) bit.
+    for(int i = 0; i < NUM_RST_ENTRIES; i++)
+    {
+	rstable_tag_read_accesses++;
+        if(rstable[cpu][i].region_id == ((trackers_l1[cpu][index].last_vpage << 1) | (trackers_l1[cpu][index].last_line_offset >> 5)))
+        {
+		rstable_read_accesses++;
+            if(rstable[cpu][i].trained_dense == 1)
+                flag = 1;
+            break;
+        }
+    }
+    for(c=0; c < NUM_RST_ENTRIES; c++)
+    {
+	rstable_tag_read_accesses++;
+        if(((curr_page << 1) | (line_offset >> 5)) == rstable[cpu][c].region_id)
+        {
+		rstable_read_accesses++;
+		rstable_write_accesses++;
+            if(rstable[cpu][c].line_access[line_offset & REGION_OFFSET_MASK] == 0)
+            {
+                rstable[cpu][c].line_access[line_offset & REGION_OFFSET_MASK] = 1;
+            }
+
+	    if(rstable[cpu][c].pos_neg_count >= MAX_POS_NEG_COUNT || rstable[cpu][c].pos_neg_count <= 0)
+	    {
+		rstable[cpu][c].pos_neg_count = MAX_POS_NEG_COUNT/2;
+	    }
+
+            if(stride>0)
+                rstable[cpu][c].pos_neg_count++;
+            else
+                rstable[cpu][c].pos_neg_count--;
+
+            if(rstable[cpu][c].trained_dense == 0)
+            {
+		int count = 0;
+		for(int i = 0; i < NUM_OF_LINES_IN_REGION; i++)
+			if(rstable[cpu][c].line_access[line_offset & REGION_OFFSET_MASK] == 1)
+				count++;
+
+                if(count > 24)	//75% of the cache lines in the region are accessed. 
+                {       
+                    rstable[cpu][c].trained_dense = 1;   
+                }
+            }
+            if (flag == 1)
+                rstable[cpu][c].tentative_dense = 1;
+            if(rstable[cpu][c].tentative_dense == 1 || rstable[cpu][c].trained_dense == 1)
+            {
+                if(rstable[cpu][c].pos_neg_count > (MAX_POS_NEG_COUNT/2))
+                    rstable[cpu][c].dir = 1;	//1 for positive direction
+                else
+                    rstable[cpu][c].dir = 0;	//0 for negative direction
+                trackers_l1[cpu][index].str_valid = 1;
+                
+                trackers_l1[cpu][index].str_dir = rstable[cpu][c].dir;
+            }
+            else
+                trackers_l1[cpu][index].str_valid = 0; 
+           
+
+	    //I tested updating the lru with mcf-782, it did not make a difference in IPC. I guess it has to do with less number of regions? Not sure. 
+	    /*for (int i=0; i<NUM_RST_ENTRIES; i++) {
+            	    //incrementing one read access for rs_table
+	    	    //rstable_read_accesses++;
+	            if (rstable[cpu][i].lru < rstable[cpu][c].lru)
+	            {
+	                rstable[cpu][i].lru++;
+	                //incrementing one write access for rs_table
+       		        rstable_tag_write_accesses++;
+            	    }
+            }
+	    rstable_tag_write_accesses++;	
+	    rstable[cpu][c].lru = 0; */
+ 
+            break;
+        }
+    }
+    //curr page has no entry in rstable. Then replace lru.
+    if(c== NUM_RST_ENTRIES)
+    {
+        //check lru
+        for( c=0;c<NUM_RST_ENTRIES;c++)
+        {
+		//incrementing one read access for rs_table
+        rstable_tag_read_accesses++;	
+            if(rstable[cpu][c].lru == (NUM_RST_ENTRIES-1))
+                break;
+        }
+        for (int i=0; i<NUM_RST_ENTRIES; i++) {
+		//incrementing one read access for rs_table
+        //rstable_read_accesses++;
+            if (rstable[cpu][i].lru < rstable[cpu][c].lru)
+	    {
+                rstable[cpu][i].lru++;
+		//incrementing one write access for rs_table
+        	rstable_tag_write_accesses++;
+	    }
+        }
+        if (flag == 1)
+            rstable[cpu][c].tentative_dense =1;
+        else
+            rstable[cpu][c].tentative_dense = 0;
+        
+        rstable[cpu][c].region_id = (curr_page << 1) | (line_offset >> 5);
+        rstable[cpu][c].trained_dense = 0;
+        rstable[cpu][c].pos_neg_count = MAX_POS_NEG_COUNT/2;
+        rstable[cpu][c].dir = 0;
+        rstable[cpu][c].lru = 0;
+        for(int i=0; i < NUM_OF_LINES_IN_REGION; i++)
+                rstable[cpu][c].line_access[i]=0;
+
+	//incrementing one write access for rs_table
+                rstable_write_accesses++;
+		rstable_tag_write_accesses++;
+    }
+    
+    
+
+// page boundary learning
+if(curr_page != trackers_l1[cpu][index].last_vpage){
+test++;
+    if(stride < 0)
+        stride += NUM_OF_LINES_IN_REGION;
+    else
+        stride -= NUM_OF_LINES_IN_REGION;
+}
+
+
+// update constant stride(CS) confidence
+trackers_l1[cpu][index].conf = update_conf(stride, trackers_l1[cpu][index].last_stride, trackers_l1[cpu][index].conf);
+
+// update CS only if confidence is zero
+if(trackers_l1[cpu][index].conf == 0)                      
+    trackers_l1[cpu][index].last_stride = stride;
+
+last_signature = trackers_l1[cpu][index].signature;
+// update complex stride(CPLX) confidence
+CSPT_l1[cpu][last_signature].conf = update_conf(stride, CSPT_l1[cpu][last_signature].stride, CSPT_l1[cpu][last_signature].conf);
+
+//incrementing one write access for cspt (includes stride updation too from the code just below.)
+cspt_write_accesses++;
+cspt_read_accesses++;	//one read access to read the last stride and confidence
+
+// update CPLX only if confidence is zero
+if(CSPT_l1[cpu][last_signature].conf == 0)
+    CSPT_l1[cpu][last_signature].stride = stride;
+
+// calculate and update new signature in IP table
+signature = update_sig_l1(last_signature, stride);
+trackers_l1[cpu][index].signature = signature;
+
+
+
+SIG_DP(
+cout << ip << ", " << cache_hit << ", " << line_addr << ", " << addr << ", " << stride << "; ";
+cout << last_signature<< ", "  << CSPT_l1[cpu][last_signature].stride<< ", "  << CSPT_l1[cpu][last_signature].conf << "; ";
+cout << trackers_l1[cpu][index].last_stride << ", " << stride << ", " << trackers_l1[cpu][index].conf << ", " << "; ";
+);
+
+    if(trackers_l1[cpu][index].str_valid == 1){                         // stream IP
+        // for stream, prefetch with twice the usual degree
+            if(prefetch_degree[cpu][1] < 3)
+                flag = 1;
+            meta_counter[cpu][0]++;
+            total_count[cpu]++;
+        for (int i=0; i<prefetch_degree[cpu][1]; i++) {
+            uint64_t pf_address = 0;
+
+            if(trackers_l1[cpu][index].str_dir == 1){                   // +ve stream
+                pf_address = (line_addr + i + 1) << LOG2_BLOCK_SIZE;
+                metadata = encode_metadata(1, S_TYPE, spec_nl[cpu]);    // stride is 1
+            }
+            else{                                                       // -ve stream
+                pf_address = (line_addr - i - 1) << LOG2_BLOCK_SIZE;
+                metadata = encode_metadata(-1, S_TYPE, spec_nl[cpu]);   // stride is -1
+            }
+
+            if(acc[cpu][1] < 75)
+                metadata = encode_metadata(0, S_TYPE, spec_nl[cpu]);
+            // Check if prefetch address is in same 4 KB page
+            if ((pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE)){
+                break;
+            }
+
+            trackers_l1[cpu][index].pref_type = S_TYPE;
+            
+	    #ifdef DO_PREF
+	    rrfilter_read_accesses++;
+	    int found_in_filter = 0;
+	    for(int i = 0; i < recent_request_filter.size(); i++)
+   	    {
+		    rrfilter_tag_read_accesses++;
+	    	    if(recent_request_filter[i] == ((pf_address >> 6) & RR_TAG_MASK))
+      		    {
+			// Prefetch address is present in RR filter
+			found_in_filter = 1;
+			break;
+  	 	    }
+	    }
+	    //Issue prefetch request only if prefetch address is not present in RR filter
+	    if(found_in_filter == 0) 
+	    { 
+		prefetch_line(ip, addr, pf_address, FILL_L1, metadata);
+		//Add to RR filter
+		rrfilter_tag_write_accesses++;
+		recent_request_filter.push_back((pf_address >> 6) & RR_TAG_MASK);
+		if(recent_request_filter.size() > NUM_OF_RR_ENTRIES)
+			recent_request_filter.erase(recent_request_filter.begin());
+	    }
+            #endif
+            num_prefs++;
+            SIG_DP(cout << "1, ");
+            }
+    } else 
+        flag = 1;
+
+
+    if(trackers_l1[cpu][index].conf > 1 && trackers_l1[cpu][index].last_stride != 0 && flag == 1){            // CS IP  
+        meta_counter[cpu][1]++; 
+        total_count[cpu]++;
+        
+        if(prefetch_degree[cpu][2] < 2)
+            flag = 1;
+        else
+            flag = 0;
+
+        for (int i=0; i<prefetch_degree[cpu][2]; i++) {
+            uint64_t pf_address = (line_addr + (trackers_l1[cpu][index].last_stride*(i+1))) << LOG2_BLOCK_SIZE;
+
+            // Check if prefetch address is in same 4 KB page
+            if ((pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE)){
+                break;
+            }
+
+            trackers_l1[cpu][index].pref_type = CS_TYPE;
+            bl_index = hash_bloom(pf_address);
+            stats[cpu][CS_TYPE].bl_request[bl_index] = 1;
+            if(acc[cpu][2] > 75)                
+                metadata = encode_metadata(trackers_l1[cpu][index].last_stride, CS_TYPE, spec_nl[cpu]);
+            else
+                metadata = encode_metadata(0, CS_TYPE, spec_nl[cpu]);
+            // if(spec_nl[cpu] == 1)
+            #ifdef DO_PREF
+	    rrfilter_read_accesses++;
+            int found_in_filter = 0;
+            for(int i = 0; i < recent_request_filter.size(); i++)
+            {
+		    rrfilter_tag_read_accesses++;
+                    if(recent_request_filter[i] == ((pf_address >> 6) & RR_TAG_MASK))
+                    {
+                        // Prefetch address is present in RR filter
+                        found_in_filter = 1;
+			break;
+                    }
+            }
+	    //Issue prefetch request only if prefetch address is not present in RR filter
+            if(found_in_filter == 0)
+            {
+                prefetch_line(ip, addr, pf_address, FILL_L1, metadata);
+                //Add to RR filter
+		rrfilter_tag_write_accesses++;
+                recent_request_filter.push_back((pf_address >> 6) & RR_TAG_MASK);
+                if(recent_request_filter.size() > NUM_OF_RR_ENTRIES)
+                        recent_request_filter.erase(recent_request_filter.begin());
+            }
+	    #endif
+            num_prefs++;
+            SIG_DP(cout << trackers_l1[cpu][index].last_stride << ", ");
+        }
+    } else 
+        flag = 1;
+
+    if(CSPT_l1[cpu][signature].conf >= 0 && CSPT_l1[cpu][signature].stride != 0 && flag == 1) {  // if conf>=0, continue looking for stride
+        int pref_offset = 0,i=0;                                                        // CPLX IP
+        meta_counter[cpu][2]++;
+        total_count[cpu]++;
+        
+        for (i=0; i<prefetch_degree[cpu][3] + CPLX_DIST; i++) {
+	    cspt_read_accesses++;
+            pref_offset += CSPT_l1[cpu][signature].stride;
+            uint64_t pf_address = ((line_addr + pref_offset) << LOG2_BLOCK_SIZE);
+
+            // Check if prefetch address is in same 4 KB page
+            if (((pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE)) || 
+                    (CSPT_l1[cpu][signature].conf == -1) ||
+                    (CSPT_l1[cpu][signature].stride == 0)){
+                // if new entry in CSPT or stride is zero, break
+                break;
+            }
+
+            // we are not prefetching at L2 for CPLX type, so encode stride as 0
+            trackers_l1[cpu][index].pref_type = CPLX_TYPE;
+            metadata = encode_metadata(0, CPLX_TYPE, spec_nl[cpu]);
+#define MIN_CONF 0 // Default 0
+            if(CSPT_l1[cpu][signature].conf > MIN_CONF && i >= CPLX_DIST){                                 // prefetch only when conf>0 for CPLX
+                bl_index = hash_bloom(pf_address);
+                stats[cpu][CPLX_TYPE].bl_request[bl_index] = 1;
+                trackers_l1[cpu][index].pref_type = 3;
+                #ifdef DO_PREF
+		rrfilter_read_accesses++;
+                int found_in_filter = 0;
+                for(int i = 0; i < recent_request_filter.size(); i++)
+                {
+			rrfilter_tag_read_accesses++;
+                        if(recent_request_filter[i] == ((pf_address >> 6) & RR_TAG_MASK))
+                        {
+                            // Prefetch address is present in RR filter
+                            found_in_filter = 1;
+			    break;
+                        }
+		}
+		//Issue prefetch request only if prefetch address is not present in RR filter
+                if(found_in_filter == 0)
+                {
+                    prefetch_line(ip, addr, pf_address, FILL_L1, metadata);
+                    //Add to RR filter
+		    rrfilter_tag_write_accesses++;
+                    recent_request_filter.push_back((pf_address >> 6) & RR_TAG_MASK);
+                    if(recent_request_filter.size() > NUM_OF_RR_ENTRIES)
+                            recent_request_filter.erase(recent_request_filter.begin());
+                }
+		#endif
+                num_prefs++;
+                SIG_DP(cout << pref_offset << ", ");
+            }
+            signature = update_sig_l1(signature, CSPT_l1[cpu][signature].stride);
+        }
+    } 
+
+
+
+// if no prefetches are issued till now, speculatively issue a next_line prefetch
+if(num_prefs == 0 && spec_nl[cpu] == 1){
+    if(flag_nl[cpu] == 0)
+        flag_nl[cpu] = 1;
+    else {
+        uint64_t pf_address = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
+	if((pf_address >> LOG2_PAGE_SIZE) != (addr >> LOG2_PAGE_SIZE))
+	{
+		// update the IP table entries
+		trackers_l1[cpu][index].last_line_offset = line_offset;
+		trackers_l1[cpu][index].last_vpage = curr_page;
+
+		return;
+	}
+        bl_index = hash_bloom(pf_address);
+        stats[cpu][NL_TYPE].bl_request[bl_index] = 1; 
+        metadata = encode_metadata(1, NL_TYPE, spec_nl[cpu]);
+        #ifdef DO_PREF
+	rrfilter_read_accesses++;
+        int found_in_filter = 0;
+        for(int i = 0; i < recent_request_filter.size(); i++)
+        {
+		rrfilter_tag_read_accesses++;
+                if(recent_request_filter[i] == ((pf_address >> 6) & RR_TAG_MASK))
+                {
+                    // Prefetch address is present in RR filter
+                    found_in_filter = 1;
+		    break;
+                }
+        }
+	//Issue prefetch request only if prefetch address is not present in RR filter
+        if(found_in_filter == 0)
+        {
+            	prefetch_line(ip, addr, pf_address, FILL_L1, metadata);
+                //Add to RR filter
+		rrfilter_tag_write_accesses++;
+                recent_request_filter.push_back((pf_address >> 6) & RR_TAG_MASK);
+                if(recent_request_filter.size() > NUM_OF_RR_ENTRIES)
+                        recent_request_filter.erase(recent_request_filter.begin());
+        }
+	#endif
+        trackers_l1[cpu][index].pref_type = NL_TYPE;
+        meta_counter[cpu][3]++;
+        total_count[cpu]++;
+        SIG_DP(cout << "1, ");
+
+        if(acc[cpu][4] < 40)
+        flag_nl[cpu] = 0;
+    }                                       // NL IP
+}
+
+
+SIG_DP(cout << endl);
+
+// update the IP table entries
+trackers_l1[cpu][index].last_line_offset = line_offset;
+trackers_l1[cpu][index].last_vpage = curr_page;
+
+
+return;
+}
+
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr, uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t v_evicted_addr, uint64_t evicted_addr, uint32_t metadata_in)
+{
+
+if(prefetch){
+uint32_t pref_type = metadata_in & 0xF00;
+pref_type = pref_type >> 8;
+
+uint64_t index = hash_bloom(addr);
+if(stats[cpu][pref_type].bl_request[index] == 1){
+    stats[cpu][pref_type].bl_filled[index] = 1;
+    stats[cpu][pref_type].bl_request[index] = 0;
+}
+}
+
+}
+void CACHE::l1d_prefetcher_final_stats()
+{
+cout << endl;
+
+uint64_t total_request=0, total_polluted=0, total_useful=0, total_late = 0;
+
+for(int i=0; i<5; i++){
+    total_request += pref_filled[cpu][i]; 
+    total_polluted += stats[cpu][i].polluted_misses; 
+    total_useful += pref_useful[cpu][i]; 
+    total_late += pref_late[cpu][i]; 
+}
+
+cout << "stream: " << endl;
+cout << "stream:times selected: " << meta_counter[cpu][0] << endl;
+cout << "stream:pref_filled: " << pref_filled[cpu][1] << endl;
+cout << "stream:pref_useful: " << pref_useful[cpu][1] << endl;
+cout << "stream:pref_late: " << pref_late[cpu][1] << endl;
+cout << "stream:misses: " << stats[cpu][1].misses << endl;
+cout << "stream:misses_by_poll: " << stats[cpu][1].polluted_misses << endl;
+cout << endl;
+
+cout << "CS: " << endl;
+cout << "CS:times selected: " << meta_counter[cpu][1] << endl;
+cout << "CS:pref_filled: " << pref_filled[cpu][2] << endl;
+cout << "CS:pref_useful: " << pref_useful[cpu][2] << endl;
+cout << "CS:pref_late: " << pref_late[cpu][2] << endl;
+cout << "CS:misses: " << stats[cpu][2].misses << endl;
+cout << "CS:misses_by_poll: " << stats[cpu][2].polluted_misses << endl;
+cout << endl;
+
+cout << "CPLX: " << endl;
+cout << "CPLX:times selected: " << meta_counter[cpu][2] << endl;
+cout << "CPLX:pref_filled: " << pref_filled[cpu][3] << endl;
+cout << "CPLX:pref_useful: " << pref_useful[cpu][3] << endl;
+cout << "CPLX:pref_late: " << pref_late[cpu][3] << endl;
+cout << "CPLX:misses: " << stats[cpu][3].misses << endl;
+cout << "CPLX:misses_by_poll: " << stats[cpu][3].polluted_misses << endl;
+cout << endl;
+
+cout << "NL_L1: " << endl;
+cout << "NL:times selected: " << meta_counter[cpu][3] << endl;
+cout << "NL:pref_filled: " << pref_filled[cpu][4] << endl;
+cout << "NL:pref_useful: " << pref_useful[cpu][4] << endl;
+cout << "NL:pref_late: " << pref_late[cpu][4] << endl;
+cout << "NL:misses: " << stats[cpu][4].misses << endl;
+cout << "NL:misses_by_poll: " << stats[cpu][4].polluted_misses << endl;
+cout << endl;
+
+
+cout << "total selections: " << total_count[cpu] << endl;
+cout << "total_filled: " << pf_fill << endl;
+cout << "total_useful: " << pf_useful << endl;
+cout << "total_late: " << total_late << endl;
+cout << "total_polluted: " << total_polluted << endl;
+cout << "total_misses_after_warmup: " << num_misses[cpu] << endl;
+
+cout<<"conflicts: " << num_conflicts <<endl;
+
+cout << "Degree Incremented Times: " << degree_incremented_times << endl;
+cout << "Degree Decremented Times: " << degree_decremented_times << endl;
+
+cout << endl;
+
+cout << "L1 IP Table Write Accesses: " <<ip_table_write_accesses << endl;
+cout << "L1 IP Table Read Accesses: " << ip_table_read_accesses << endl; 
+cout << "L1 RST Write Accesses: " << rstable_write_accesses << endl;
+cout << "L1 RST Read Accesses: " << rstable_read_accesses << endl;             
+cout << "L1 CSPT Write Accesses: " <<cspt_write_accesses << endl;
+cout << "L1 CSPT Read Accesses: " << cspt_read_accesses << endl;
+cout << "L1 RR Filter Tag Write Accesses: " << rrfilter_tag_write_accesses << endl;  
+cout << "L1 RR Filter Tag Read Accesses: " << rrfilter_tag_read_accesses << endl;
+cout << "L1 IP Table Tag Write Accesses: " <<ip_table_tag_write_accesses << endl;
+cout << "L1 IP Table Tag Read Accesses: " << ip_table_tag_read_accesses << endl;
+cout << "L1 RST Tag Write Accesses: " << rstable_tag_write_accesses << endl;
+cout << "L1 RST Tag Read Accesses: " << rstable_tag_read_accesses << endl;
+cout << "L1 RR Filter Write Accesses: " << rrfilter_write_accesses << endl;  
+cout << "L1 RR Filter Read Accesses: " << rrfilter_read_accesses << endl;
+
+cout << "test: " << test << endl;
+}

--- a/src/prefetcher/champsim/csenv/ipcp_table_sizes.h
+++ b/src/prefetcher/champsim/csenv/ipcp_table_sizes.h
@@ -1,0 +1,175 @@
+//-------------------- Setting the sizes of IPCP prefetcher tables -----------------------
+//Neelu: These are the two parameters of interest: CONFIG_1X and SCALE_ONLY_IP_TABLE
+
+
+//CONFIG_1X keeps the original table sizes from the paper. CONFIG_1X will double the table sizes, and so on. 
+
+//Valid Inputs: PT25X, PT5X, 1X, 2X, 4X, 8X, 16X, 32X, 64X, 128X, 256X. 
+#ifndef IPCP_H
+#define IPCP_H
+
+
+#define CONFIG_1X
+
+
+// SCALE_ONLY_IP_TABLE will affect the size of only the IP_TABLE, and leave the other table sizes same as they are in the paper. 
+
+#define SCALE_ONLY_IP_TABLE
+
+
+
+//----------------- From here, the knobs are defined. Don't change the configs. You can add another config. ------------
+
+#ifdef SCALE_ONLY_IP_TABLE
+#define NUM_CSPT_ENTRIES 128                                // = 2^NUM_SIG_BITS                                                               
+#define NUM_SIG_BITS 7                                      // num of bits in signature        
+#define NUM_RST_ENTRIES 8 
+#endif
+
+// ------------------------------
+
+#ifdef CONFIG_PT25X
+
+#define NUM_IP_TABLE_L1_ENTRIES 16
+#define NUM_IP_INDEX_BITS 4
+
+#ifndef SCALE_ONLY_IP_TABLE
+	#define NUM_CSPT_ENTRIES 32                                // = 2^NUM_SIG_BITS
+	#define NUM_SIG_BITS 5                                      // num of bits in signature 
+	#define NUM_RST_ENTRIES 2  	
+#endif
+
+#endif
+
+
+// ------------------------------        
+
+#ifdef CONFIG_1X 
+
+	#define NUM_IP_TABLE_L1_ENTRIES 32 
+        #define NUM_IP_INDEX_BITS 5   
+#ifndef SCALE_ONLY_IP_TABLE             
+        #define NUM_CSPT_ENTRIES 64                                // = 2^NUM_SIG_BITS 
+        #define NUM_SIG_BITS 6                                      // num of bits in signature      
+	#define NUM_RST_ENTRIES 4  
+#endif        
+#endif   
+
+
+// ------------------------------ 
+
+#ifdef CONFIG_1X
+
+	#define NUM_IP_TABLE_L1_ENTRIES 64
+	#define NUM_IP_INDEX_BITS 6
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 128				   // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 7                                      // num of bits in signature
+	#define NUM_RST_ENTRIES 8
+#endif
+#endif
+
+// ------------------------------
+
+#ifdef CONFIG_1X
+	
+	#define NUM_IP_TABLE_L1_ENTRIES 128
+	#define NUM_IP_INDEX_BITS 7
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 256                               // = 2^NUM_SIG_BITS
+	#define NUM_SIG_BITS 8                                      // num of bits in signature   
+	#define NUM_RST_ENTRIES 16
+#endif
+#endif
+
+// ------------------------------
+
+#ifdef CONFIG_1X
+
+	#define NUM_IP_TABLE_L1_ENTRIES 256
+	#define NUM_IP_INDEX_BITS 8
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 512				   // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 9                                      // num of bits in signature 
+	#define NUM_RST_ENTRIES 32
+#endif
+#endif
+
+// ------------------------------
+
+#ifdef CONFIG_1X
+
+	#define NUM_IP_TABLE_L1_ENTRIES 512
+	#define NUM_IP_INDEX_BITS 9
+#ifndef SCALE_ONLY_IP_TABLE  
+	#define NUM_CSPT_ENTRIES 1024                               // = 2^NUM_SIG_BITS
+	#define NUM_SIG_BITS 10					      // num of bits in signature 
+	#define NUM_RST_ENTRIES 64
+#endif
+#endif
+
+// ------------------------------  
+
+#ifdef CONFIG_1X
+	
+	#define NUM_IP_TABLE_L1_ENTRIES 1024
+	#define NUM_IP_INDEX_BITS 10
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 2048                               // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 11                                      // num of bits in signature  
+	#define NUM_RST_ENTRIES 128
+#endif
+#endif
+
+// ------------------------------  
+
+#ifdef CONFIG_32X
+	
+	#define NUM_IP_TABLE_L1_ENTRIES 2048
+	#define NUM_IP_INDEX_BITS 11
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 4096                               // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 12                                      // num of bits in signature 
+	#define NUM_RST_ENTRIES 256
+#endif
+#endif
+
+// ------------------------------
+
+#ifdef CONFIG_64X
+	
+	#define NUM_IP_TABLE_L1_ENTRIES 4096
+	#define NUM_IP_INDEX_BITS 12
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 8192                               // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 13                                      // num of bits in signature
+	#define NUM_RST_ENTRIES 512
+#endif
+#endif
+
+// ------------------------------ 
+
+#ifdef CONFIG_128X 
+	
+	#define NUM_IP_TABLE_L1_ENTRIES 8192
+	#define NUM_IP_INDEX_BITS 13
+#ifndef SCALE_ONLY_IP_TABLE 
+	#define NUM_CSPT_ENTRIES 16384                               // = 2^NUM_SIG_BITS 
+	#define NUM_SIG_BITS 14                                      // num of bits in signature
+	#define NUM_RST_ENTRIES 1024
+#endif
+#endif
+
+// ------------------------------ 
+
+#ifdef CONFIG_256X
+
+	#define NUM_IP_TABLE_L1_ENTRIES 16384
+	#define NUM_IP_INDEX_BITS 14
+#ifndef SCALE_ONLY_IP_TABLE
+	#define NUM_CSPT_ENTRIES 32768
+	#define NUM_SIG_BITS 15                                      // num of bits in signature 
+	#define NUM_RST_ENTRIES 2048
+#endif
+#endif
+#endif

--- a/src/prefetcher/champsim/csenv/memory_class.h
+++ b/src/prefetcher/champsim/csenv/memory_class.h
@@ -1,0 +1,17 @@
+/* Universal ChampSim shim: minimal fake of ChampSim's inc/memory_class.h.
+ * Only the access TYPE codes that DPC3 prefetcher sources branch on. */
+#ifndef MEMORY_CLASS_H
+#define MEMORY_CLASS_H
+
+#include "champsim.h"
+
+#define LOAD                 0
+#define RFO                  1
+#define PREFETCH             2
+#define WRITEBACK            3
+#define LOAD_TRANSLATION     4
+#define PREFETCH_TRANSLATION 5
+#define TRANSLATION_FROM_L1D 6
+#define NUM_TYPES            7
+
+#endif  // MEMORY_CLASS_H

--- a/src/prefetcher/champsim/csenv/mlop_dpc3.l1d.inc
+++ b/src/prefetcher/champsim/csenv/mlop_dpc3.l1d.inc
@@ -1,0 +1,900 @@
+/* Multi-Lookahead Offset Prefetcher (MLOP) */
+
+#include "cache.h"
+#include <bits/stdc++.h>
+
+using namespace std;
+
+namespace L1D_PREF_2 {
+
+/**
+ * A class for printing beautiful data tables.
+ * It's useful for logging the information contained in tabular structures.
+ */
+class Table {
+  public:
+    Table(int width, int height) : width(width), height(height), cells(height, vector<string>(width)) {}
+
+    void set_row(int row, const vector<string> &data, int start_col = 0) {
+        // assert(data.size() + start_col == this->width);
+        for (unsigned col = start_col; col < this->width; col += 1)
+            this->set_cell(row, col, data[col]);
+    }
+
+    void set_col(int col, const vector<string> &data, int start_row = 0) {
+        // assert(data.size() + start_row == this->height);
+        for (unsigned row = start_row; row < this->height; row += 1)
+            this->set_cell(row, col, data[row]);
+    }
+
+    void set_cell(int row, int col, string data) {
+        // assert(0 <= row && row < (int)this->height);
+        // assert(0 <= col && col < (int)this->width);
+        this->cells[row][col] = data;
+    }
+
+    void set_cell(int row, int col, double data) {
+        ostringstream oss;
+        oss << setw(11) << fixed << setprecision(8) << data;
+        this->set_cell(row, col, oss.str());
+    }
+
+    void set_cell(int row, int col, int64_t data) {
+        ostringstream oss;
+        oss << setw(11) << std::left << data;
+        this->set_cell(row, col, oss.str());
+    }
+
+    void set_cell(int row, int col, int data) { this->set_cell(row, col, (int64_t)data); }
+
+    void set_cell(int row, int col, uint64_t data) {
+        ostringstream oss;
+        oss << "0x" << setfill('0') << setw(16) << hex << data;
+        this->set_cell(row, col, oss.str());
+    }
+
+    /**
+     * @return The entire table as a string
+     */
+    string to_string() {
+        vector<int> widths;
+        for (unsigned i = 0; i < this->width; i += 1) {
+            int max_width = 0;
+            for (unsigned j = 0; j < this->height; j += 1)
+                max_width = max(max_width, (int)this->cells[j][i].size());
+            widths.push_back(max_width + 2);
+        }
+        string out;
+        out += Table::top_line(widths);
+        out += this->data_row(0, widths);
+        for (unsigned i = 1; i < this->height; i += 1) {
+            out += Table::mid_line(widths);
+            out += this->data_row(i, widths);
+        }
+        out += Table::bot_line(widths);
+        return out;
+    }
+
+    string data_row(int row, const vector<int> &widths) {
+        string out;
+        for (unsigned i = 0; i < this->width; i += 1) {
+            string data = this->cells[row][i];
+            data.resize(widths[i] - 2, ' ');
+            out += " | " + data;
+        }
+        out += " |\n";
+        return out;
+    }
+
+    static string top_line(const vector<int> &widths) { return Table::line(widths, "┌", "┬", "┐"); }
+
+    static string mid_line(const vector<int> &widths) { return Table::line(widths, "├", "┼", "┤"); }
+
+    static string bot_line(const vector<int> &widths) { return Table::line(widths, "└", "┴", "┘"); }
+
+    static string line(const vector<int> &widths, string left, string mid, string right) {
+        string out = " " + left;
+        for (unsigned i = 0; i < widths.size(); i += 1) {
+            int w = widths[i];
+            for (int j = 0; j < w; j += 1)
+                out += "─";
+            if (i != widths.size() - 1)
+                out += mid;
+            else
+                out += right;
+        }
+        return out + "\n";
+    }
+
+  private:
+    unsigned width;
+    unsigned height;
+    vector<vector<string>> cells;
+};
+
+template <class T> class SetAssociativeCache {
+  public:
+    class Entry {
+      public:
+        uint64_t key;
+        uint64_t index;
+        uint64_t tag;
+        bool valid;
+        T data;
+    };
+
+    SetAssociativeCache(int size, int num_ways, int debug_level = 0)
+        : size(size), num_ways(num_ways), num_sets(size / num_ways), entries(num_sets, vector<Entry>(num_ways)),
+          cams(num_sets), debug_level(debug_level) {
+        // assert(size % num_ways == 0);
+        for (int i = 0; i < num_sets; i += 1)
+            for (int j = 0; j < num_ways; j += 1)
+                entries[i][j].valid = false;
+        /* calculate `index_len` (number of bits required to store the index) */
+        for (int max_index = num_sets - 1; max_index > 0; max_index >>= 1)
+            this->index_len += 1;
+    }
+
+    /**
+     * Invalidates the entry corresponding to the given key.
+     * @return A pointer to the invalidated entry
+     */
+    Entry *erase(uint64_t key) {
+        Entry *entry = this->find(key);
+        uint64_t index = key % this->num_sets;
+        uint64_t tag = key / this->num_sets;
+        auto &cam = cams[index];
+        int num_erased = cam.erase(tag);
+        if (entry)
+            entry->valid = false;
+        // assert(entry ? num_erased == 1 : num_erased == 0);
+        return entry;
+    }
+
+    /**
+     * @return The old state of the entry that was updated
+     */
+    Entry insert(uint64_t key, const T &data) {
+        Entry *entry = this->find(key);
+        if (entry != nullptr) {
+            Entry old_entry = *entry;
+            entry->data = data;
+            return old_entry;
+        }
+        uint64_t index = key % this->num_sets;
+        uint64_t tag = key / this->num_sets;
+        vector<Entry> &set = this->entries[index];
+        int victim_way = -1;
+        for (int i = 0; i < this->num_ways; i += 1)
+            if (!set[i].valid) {
+                victim_way = i;
+                break;
+            }
+        if (victim_way == -1) {
+            victim_way = this->select_victim(index);
+        }
+        Entry &victim = set[victim_way];
+        Entry old_entry = victim;
+        victim = {key, index, tag, true, data};
+        auto &cam = cams[index];
+        if (old_entry.valid) {
+            int num_erased = cam.erase(old_entry.tag);
+            // assert(num_erased == 1);
+        }
+        cam[tag] = victim_way;
+        return old_entry;
+    }
+
+    Entry *find(uint64_t key) {
+        uint64_t index = key % this->num_sets;
+        uint64_t tag = key / this->num_sets;
+        auto &cam = cams[index];
+        if (cam.find(tag) == cam.end())
+            return nullptr;
+        int way = cam[tag];
+        Entry &entry = this->entries[index][way];
+        // assert(entry.tag == tag && entry.valid);
+        return &entry;
+    }
+
+    /**
+     * Creates a table with the given headers and populates the rows by calling `write_data` on all
+     * valid entries contained in the cache. This function makes it easy to visualize the contents
+     * of a cache.
+     * @return The constructed table as a string
+     */
+    string log(vector<string> headers) {
+        vector<Entry> valid_entries = this->get_valid_entries();
+        Table table(headers.size(), valid_entries.size() + 1);
+        table.set_row(0, headers);
+        for (unsigned i = 0; i < valid_entries.size(); i += 1)
+            this->write_data(valid_entries[i], table, i + 1);
+        return table.to_string();
+    }
+
+    int get_index_len() { return this->index_len; }
+
+    void set_debug_level(int debug_level) { this->debug_level = debug_level; }
+
+  protected:
+    /* should be overriden in children */
+    virtual void write_data(Entry &entry, Table &table, int row) {}
+
+    /**
+     * @return The way of the selected victim
+     */
+    virtual int select_victim(uint64_t index) {
+        /* random eviction policy if not overriden */
+        return rand() % this->num_ways;
+    }
+
+    vector<Entry> get_valid_entries() {
+        vector<Entry> valid_entries;
+        for (int i = 0; i < num_sets; i += 1)
+            for (int j = 0; j < num_ways; j += 1)
+                if (entries[i][j].valid)
+                    valid_entries.push_back(entries[i][j]);
+        return valid_entries;
+    }
+
+    int size;
+    int num_ways;
+    int num_sets;
+    int index_len = 0; /* in bits */
+    vector<vector<Entry>> entries;
+    vector<unordered_map<uint64_t, int>> cams;
+    int debug_level = 0;
+};
+
+template <class T> class LRUSetAssociativeCache : public SetAssociativeCache<T> {
+    typedef SetAssociativeCache<T> Super;
+
+  public:
+    LRUSetAssociativeCache(int size, int num_ways, int debug_level = 0)
+        : Super(size, num_ways, debug_level), lru(this->num_sets, vector<uint64_t>(num_ways)) {}
+
+    void set_mru(uint64_t key) { *this->get_lru(key) = this->t++; }
+
+    void set_lru(uint64_t key) { *this->get_lru(key) = 0; }
+
+  protected:
+    /* @override */
+    int select_victim(uint64_t index) {
+        vector<uint64_t> &lru_set = this->lru[index];
+        return min_element(lru_set.begin(), lru_set.end()) - lru_set.begin();
+    }
+
+    uint64_t *get_lru(uint64_t key) {
+        uint64_t index = key % this->num_sets;
+        uint64_t tag = key / this->num_sets;
+        // assert(this->cams[index].count(tag) == 1);
+        int way = this->cams[index][tag];
+        return &this->lru[index][way];
+    }
+
+    vector<vector<uint64_t>> lru;
+    uint64_t t = 1;
+};
+
+/**
+ * A very simple and efficient hash function that:
+ * 1) Splits key into blocks of length `index_len` bits and computes the XOR of all blocks.
+ * 2) Replaces the least significant block of key with computed block.
+ * With this hash function, the index will depend on all bits in the key. As a consequence, entries
+ * will be more randomly distributed among the sets.
+ * NOTE: Applying this hash function twice with the same `index_len` acts as the identity function.
+ */ 
+uint64_t hash_index(uint64_t key, int index_len) {
+    if (index_len == 0)
+        return key;
+    for (uint64_t tag = (key >> index_len); tag > 0; tag >>= index_len)
+        key ^= tag & ((1 << index_len) - 1);
+    return key;
+}
+
+/*=== End Of Cache Framework ===*/
+
+/**
+ * The access map table records blocks as being in one of 3 general states:
+ * ACCESS, PREFETCH, or INIT.
+ * The PREFETCH state is actually composed of up to 3 sub-states:
+ * L1-PREFETCH, L2-PREFETCH, or L3-PREFETCH.
+ * This version of MLOP does not prefetch into L3 so there are 4 states in total (2-bit states).
+ */
+enum State { INIT = 0, ACCESS = 1, PREFTCH = 2 };
+char state_char[] = {'I', 'A', 'P'};
+
+string map_to_string(const vector<State> &access_map, const vector<int> &prefetch_map) {
+    ostringstream oss;
+    for (unsigned i = 0; i < access_map.size(); i += 1)
+        if (access_map[i] == State::PREFTCH) {
+            oss << prefetch_map[i];
+        } else {
+            oss << state_char[access_map[i]];
+        }
+    return oss.str();
+}
+
+class AccessMapData {
+  public:
+    /* block states are represented with a `State` and an `int` in this software implementation but
+     * in a hardware implementation, they'd be represented with only 2 bits. */
+    vector<State> access_map;
+    vector<int> prefetch_map;
+
+    deque<int> hist_queue;
+};
+
+class AccessMapTable : public LRUSetAssociativeCache<AccessMapData> {
+    typedef LRUSetAssociativeCache<AccessMapData> Super;
+
+  public:
+    /* NOTE: zones are equivalent to pages (64 blocks) in this implementation */
+    AccessMapTable(int size, int blocks_in_zone, int queue_size, int debug_level = 0, int num_ways = 16)
+        : Super(size, num_ways, debug_level), blocks_in_zone(blocks_in_zone), queue_size(queue_size) {
+        if (this->debug_level >= 1)
+            cerr << "AccessMapTable::AccessMapTable(size=" << size << ", blocks_in_zone=" << blocks_in_zone
+                 << ", queue_size=" << queue_size << ", debug_level=" << debug_level << ", num_ways=" << num_ways << ")"
+                 << endl;
+    }
+
+    /**
+     * Sets specified block to given state. If new state is ACCESS, the block will also be pushed in the zone's queue.
+     */
+    void set_state(uint64_t block_number, State new_state, int new_fill_level = 0) {
+        if (this->debug_level >= 2)
+            cerr << "AccessMapTable::set_state(block_number=0x" << hex << block_number
+                 << ", new_state=" << state_char[new_state] << ", new_fill_level=" << new_fill_level << ")" << dec
+                 << endl;
+
+        // if (new_state != State::PREFTCH)
+        //     assert(new_fill_level == 0);
+        // else
+        //     assert(new_fill_level == FILL_L1 || new_fill_level == FILL_L2 || new_fill_level == FILL_LLC);
+
+        uint64_t zone_number = block_number / this->blocks_in_zone;
+        int zone_offset = block_number % this->blocks_in_zone;
+
+        uint64_t key = this->build_key(zone_number);
+        Entry *entry = Super::find(key);
+        if (!entry) {
+            // assert(new_state != State::PREFTCH);
+            if (new_state == State::INIT)
+                return;
+            Super::insert(key, {vector<State>(blocks_in_zone, State::INIT), vector<int>(blocks_in_zone, 0)});
+            entry = Super::find(key);
+            // assert(entry->data.hist_queue.empty());
+        }
+
+        auto &access_map = entry->data.access_map;
+        auto &prefetch_map = entry->data.prefetch_map;
+        auto &hist_queue = entry->data.hist_queue;
+
+        if (new_state == State::ACCESS) {
+            Super::set_mru(key);
+
+            /* insert access into queue */
+            hist_queue.push_front(zone_offset);
+            if (hist_queue.size() > this->queue_size)
+                hist_queue.pop_back();
+        }
+
+        State old_state = access_map[zone_offset];
+        int old_fill_level = prefetch_map[zone_offset];
+
+        vector<State> old_access_map = access_map;
+        vector<int> old_prefetch_map = prefetch_map;
+
+        access_map[zone_offset] = new_state;
+        prefetch_map[zone_offset] = new_fill_level;
+
+        if (new_state == State::INIT) {
+            /* delete entry if access map is empty (all in state INIT) */
+            bool all_init = true;
+            for (unsigned i = 0; i < this->blocks_in_zone; i += 1)
+                if (access_map[i] != State::INIT) {
+                    all_init = false;
+                    break;
+                }
+            if (all_init)
+                Super::erase(key);
+        }
+
+        if (this->debug_level >= 2) {
+            cerr << "[AccessMapTable::set_state] zone_number=0x" << hex << zone_number << dec
+                 << ", zone_offset=" << setw(2) << zone_offset << ": state transition from " << state_char[old_state]
+                 << " to " << state_char[new_state] << endl;
+            if (old_state != new_state || old_fill_level != new_fill_level) {
+                cerr << "[AccessMapTable::set_state] old_access_map=" << map_to_string(old_access_map, old_prefetch_map)
+                     << endl;
+                cerr << "[AccessMapTable::set_state] new_access_map=" << map_to_string(access_map, prefetch_map)
+                     << endl;
+            }
+        }
+    }
+
+    Entry *find(uint64_t zone_number) {
+        if (this->debug_level >= 2)
+            cerr << "AccessMapTable::find(zone_number=0x" << hex << zone_number << ")" << dec << endl;
+        uint64_t key = this->build_key(zone_number);
+        return Super::find(key);
+    }
+
+    string log() {
+        vector<string> headers({"Zone", "Access Map"});
+        return Super::log(headers);
+    }
+
+  private:
+    /* @override */
+    void write_data(Entry &entry, Table &table, int row) {
+        uint64_t zone_number = hash_index(entry.key, this->index_len);
+        table.set_cell(row, 0, zone_number);
+        table.set_cell(row, 1, map_to_string(entry.data.access_map, entry.data.prefetch_map));
+    }
+
+    uint64_t build_key(uint64_t zone_number) {
+        uint64_t key = zone_number; /* no truncation (52 bits) */
+        return hash_index(key, this->index_len);
+    }
+
+    unsigned blocks_in_zone;
+    unsigned queue_size;
+
+    /*===================================================================*/
+    /* Entry   = [tag, map, queue, valid, LRU]                           */
+    /* Storage = size * (52 - lg(sets) + 64 * 2 + 15 * 6 + 1 + lg(ways)) */
+    /* L1D: 256 * (52 - lg(16) + 128 + 90 + 1 + lg(16)) = 8672 Bytes     */
+    /*===================================================================*/
+};
+
+template <class T> inline T square(T x) { return x * x; }
+
+class MLOP {
+  public:
+    MLOP(int blocks_in_zone, int amt_size, const int PF_DEGREE, const int NUM_UPDATES, const double L1D_THRESH,
+        const double L2C_THRESH, const double LLC_THRESH, int debug_level)
+        : PF_DEGREE(PF_DEGREE), NUM_UPDATES(NUM_UPDATES), L1D_THRESH(L1D_THRESH * NUM_UPDATES),
+          L2C_THRESH(L2C_THRESH * NUM_UPDATES), LLC_THRESH(LLC_THRESH * NUM_UPDATES), ORIGIN(blocks_in_zone - 1),
+          MAX_OFFSET(blocks_in_zone - 1), NUM_OFFSETS(2 * blocks_in_zone - 1), blocks_in_zone(blocks_in_zone),
+          access_map_table(amt_size, blocks_in_zone, PF_DEGREE - 1, debug_level), pf_offset(PF_DEGREE, vector<int>()),
+          offset_scores(PF_DEGREE, vector<int>(2 * blocks_in_zone - 1, 0)), pf_level(PF_DEGREE, 0),
+          debug_level(debug_level) {
+        if (this->debug_level >= 1)
+            cerr << "MLOP::MLOP(blocks_in_zone=" << blocks_in_zone << ", amt_size=" << amt_size
+                 << ", PF_DEGREE=" << PF_DEGREE << ", NUM_UPDATES=" << NUM_UPDATES << ", L1D_THRESH=" << L1D_THRESH
+                 << ", L2C_THRESH=" << L2C_THRESH << ", LLC_THRESH=" << LLC_THRESH << ", debug_level=" << debug_level
+                 << ")" << endl;
+        // assert(ORIGIN == MAX_OFFSET);
+        // assert(NUM_OFFSETS == MAX_OFFSET * 2 + 1);
+        // assert((int)offset_scores[0].size() == NUM_OFFSETS);
+    }
+
+    /**
+     * Updates MLOP's state based on the most recent trigger access (LOAD miss/prefetch-hit).
+     * @param block_number The block address of the most recent trigger access
+     */
+    void access(uint64_t block_number) {
+        if (this->debug_level >= 2)
+            cerr << "MLOP::access(block_number=0x" << hex << block_number << ")" << dec << endl;
+
+        uint64_t zone_number = block_number / this->blocks_in_zone;
+        int zone_offset = block_number % this->blocks_in_zone;
+
+        if (this->debug_level >= 2)
+            cerr << "[MLOP::access] zone_number=0x" << hex << zone_number << dec << ", zone_offset=" << zone_offset
+                 << endl;
+
+        // for (int i = 0; i < PF_DEGREE; i += 1)
+        //     assert(this->offset_scores[i][ORIGIN] == 0);
+
+        /* update scores */
+        AccessMapTable::Entry *entry = this->access_map_table.find(zone_number);
+        if (!entry) {
+            /* stats */
+            this->zone_cnt += 1;
+            if (this->zone_cnt == TRACKED_ZONE_CNT) {
+                this->tracked_zone_number = zone_number;
+                this->tracking = true;
+                this->zone_life.push_back(string(this->blocks_in_zone, state_char[State::INIT]));
+            }
+            /* ===== */
+            return;
+        }
+        vector<State> access_map = entry->data.access_map;
+        if (access_map[zone_offset] == State::ACCESS)
+            return; /* ignore repeated trigger access */
+        this->update_cnt += 1;
+        const deque<int> &queue = entry->data.hist_queue;
+        for (int d = 0; d <= (int)queue.size(); d += 1) {
+            /* unmark latest access to increase prediction depth */
+            if (d != 0) {
+                int idx = queue[d - 1];
+                // assert(0 <= idx && idx < this->blocks_in_zone);
+                access_map[idx] = State::INIT;
+            }
+            for (int i = 0; i < this->blocks_in_zone; i += 1) {
+                if (access_map[i] == State::ACCESS) {
+                    int offset = zone_offset - i;
+                    if (-MAX_OFFSET <= offset && offset <= +MAX_OFFSET && offset != 0)
+                        this->offset_scores[d][ORIGIN + offset] += 1;
+                }
+            }
+        }
+
+        /* update prefetching offsets if round is finished */
+        if (this->update_cnt == NUM_UPDATES) {
+            if (this->debug_level >= 1)
+                cerr << "[MLOP::access] Round finished!" << endl;
+
+            /* reset `update_cnt` and clear `pf_level` and `pf_offset` */
+            this->update_cnt = 0;
+            this->pf_level = vector<int>(PF_DEGREE, 0);
+            this->pf_offset = vector<vector<int>>(PF_DEGREE, vector<int>());
+
+            /* calculate maximum score for all degrees */
+            vector<int> max_scores(PF_DEGREE, 0);
+            for (int i = 0; i < PF_DEGREE; i += 1) {
+                max_scores[i] = *max_element(this->offset_scores[i].begin(), this->offset_scores[i].end());
+                /* `max_scores` should be decreasing */
+                // if (i > 0)
+                //     assert(max_scores[i] <= max_scores[i - 1]);
+            }
+
+            int fill_level = 0;
+            vector<bool> pf_offset_map(NUM_OFFSETS, false);
+            for (int d = PF_DEGREE - 1; d >= 0; d -= 1) {
+                /* check thresholds */
+                if (max_scores[d] >= L1D_THRESH)
+                    fill_level = FILL_L1;
+                else if (max_scores[d] >= L2C_THRESH)
+                    fill_level = FILL_L2;
+                else if (max_scores[d] >= LLC_THRESH)
+                    fill_level = FILL_LLC;
+                else
+                    continue;
+
+                /* select offsets with highest score */
+                vector<int> best_offsets;
+                for (int i = -MAX_OFFSET; i <= +MAX_OFFSET; i += 1) {
+                    int &cur_score = this->offset_scores[d][ORIGIN + i];
+                    // assert(0 <= cur_score && cur_score <= NUM_UPDATES);
+                    if (cur_score == max_scores[d] && !pf_offset_map[ORIGIN + i])
+                        best_offsets.push_back(i);
+                }
+
+                this->pf_level[d] = fill_level;
+                this->pf_offset[d] = best_offsets;
+
+                /* mark in `pf_offset_map` to avoid duplicate prefetch offsets */
+                for (int i = 0; i < (int)best_offsets.size(); i += 1)
+                    pf_offset_map[ORIGIN + best_offsets[i]] = true;
+            }
+
+            /* reset `offset_scores` */
+            this->offset_scores = vector<vector<int>>(PF_DEGREE, vector<int>(NUM_OFFSETS, 0));
+
+            /* print selected prefetching offsets if debug is on */
+            if (this->debug_level >= 1) {
+                for (int d = 0; d < PF_DEGREE; d += 1) {
+                    cerr << "[MLOP::access] Degree=" << setw(2) << d + 1 << ", Level=";
+
+                    if (this->pf_level[d] == 0)
+                        cerr << "No";
+                    if (this->pf_level[d] == FILL_L1)
+                        cerr << "L1";
+                    if (this->pf_level[d] == FILL_L2)
+                        cerr << "L2";
+                    if (this->pf_level[d] == FILL_LLC)
+                        cerr << "L3";
+
+                    cerr << ", Offsets: ";
+                    if (this->pf_offset[d].size() == 0)
+                        cerr << "None";
+                    for (int i = 0; i < (int)this->pf_offset[d].size(); i += 1) {
+                        cerr << this->pf_offset[d][i];
+                        if (i < (int)this->pf_offset[d].size() - 1)
+                            cerr << ", ";
+                    }
+                    cerr << endl;
+                }
+            }
+
+            /* stats */
+            this->round_cnt += 1;
+
+            int cur_pf_degree = 0;
+            for (const bool &x : pf_offset_map)
+                cur_pf_degree += (x ? 1 : 0);
+            this->pf_degree_sum += cur_pf_degree;
+            this->pf_degree_sqr_sum += square(cur_pf_degree);
+
+            uint64_t max_score_le = max_scores[PF_DEGREE - 1];
+            uint64_t max_score_ri = max_scores[0];
+            this->max_score_le_sum += max_score_le;
+            this->max_score_ri_sum += max_score_ri;
+            this->max_score_le_sqr_sum += square(max_score_le);
+            this->max_score_ri_sqr_sum += square(max_score_ri);
+            /* ===== */
+        }
+    }
+
+    /**
+     * @param block_number The block address of the most recent LOAD access
+     */
+    void prefetch(CACHE *cache, uint64_t block_number) {
+        if (this->debug_level >= 2) {
+            cerr << "MLOP::prefetch(cache=" << cache->NAME << "-" << cache->cpu << ", block_number=0x" << hex
+                 << block_number << dec << ")" << endl;
+        }
+        int pf_issued = 0;
+        uint64_t zone_number = block_number / this->blocks_in_zone;
+        int zone_offset = block_number % this->blocks_in_zone;
+        AccessMapTable::Entry *entry = this->access_map_table.find(zone_number);
+        // assert(entry); /* I expect `mark` to have been called before `prefetch` */
+        const vector<State> &access_map = entry->data.access_map;
+        const vector<int> &prefetch_map = entry->data.prefetch_map;
+        if (this->debug_level >= 2) {
+            cerr << "[MLOP::prefetch] old_access_map=" << map_to_string(access_map, prefetch_map) << endl;
+        }
+        for (int d = 0; d < PF_DEGREE; d += 1) {
+            for (auto &cur_pf_offset : this->pf_offset[d]) {
+                // assert(this->pf_level[d] > 0);
+                int offset_to_prefetch = zone_offset + cur_pf_offset;
+
+                /* use `access_map` to filter prefetches */
+                if (access_map[offset_to_prefetch] == State::ACCESS)
+                    continue;
+                if (access_map[offset_to_prefetch] == State::PREFTCH &&
+                    prefetch_map[offset_to_prefetch] <= this->pf_level[d])
+                    continue;
+
+                if (this->is_inside_zone(offset_to_prefetch) && cache->PQ.occupancy < cache->PQ.SIZE &&
+                    cache->PQ.occupancy + cache->MSHR.occupancy < cache->MSHR.SIZE - 1) {
+                    uint64_t pf_block_number = block_number + cur_pf_offset;
+                    uint64_t base_addr = block_number << LOG2_BLOCK_SIZE;
+                    uint64_t pf_addr = pf_block_number << LOG2_BLOCK_SIZE;
+                    int ok = cache->prefetch_line(0, base_addr, pf_addr, this->pf_level[d], 0);
+                    // assert(ok == 1);
+                    this->mark(pf_block_number, State::PREFTCH, this->pf_level[d]);
+                    pf_issued += 1;
+                }
+            }
+        }
+        if (this->debug_level >= 2) {
+            cerr << "[MLOP::prefetch] new_access_map=" << map_to_string(access_map, prefetch_map) << endl;
+            cerr << "[MLOP::prefetch] issued " << pf_issued << " prefetch(es)" << endl;
+        }
+    }
+
+    void mark(uint64_t block_number, State state, int fill_level = 0) {
+        this->access_map_table.set_state(block_number, state, fill_level);
+    }
+
+    void set_debug_level(int debug_level) {
+        this->debug_level = debug_level;
+        this->access_map_table.set_debug_level(debug_level);
+    }
+
+    string log_offset_scores() {
+        Table table(1 + PF_DEGREE, this->offset_scores.size() + 1);
+        vector<string> headers = {"Offset"};
+        for (int d = 0; d < PF_DEGREE; d += 1) {
+            ostringstream oss;
+            oss << "Score[d=" << d + 1 << "]";
+            headers.push_back(oss.str());
+        }
+        table.set_row(0, headers);
+        for (int i = -(this->blocks_in_zone - 1); i <= +(this->blocks_in_zone - 1); i += 1) {
+            table.set_cell(i + this->blocks_in_zone, 0, i);
+            for (int d = 0; d < PF_DEGREE; d += 1)
+                table.set_cell(i + this->blocks_in_zone, d + 1, this->offset_scores[d][ORIGIN + i]);
+        }
+        return table.to_string();
+    }
+
+    void log() {
+        cerr << "Access Map Table:" << dec << endl;
+        cerr << this->access_map_table.log();
+
+        cerr << "Offset Scores:" << endl;
+        cerr << this->log_offset_scores();
+    }
+
+    /*========== stats ==========*/
+
+    void track(uint64_t block_number) {
+        uint64_t zone_number = block_number / this->blocks_in_zone;
+        if (this->tracking && zone_number == this->tracked_zone_number) {
+            AccessMapTable::Entry *entry = this->access_map_table.find(zone_number);
+            if (!entry) {
+                this->tracking = false; /* end of zone lifetime, stop tracking */
+                this->zone_life.push_back(string(this->blocks_in_zone, state_char[State::INIT]));
+                return;
+            }
+            const vector<State> &access_map = entry->data.access_map;
+            const vector<int> &prefetch_map = entry->data.prefetch_map;
+            string s = map_to_string(access_map, prefetch_map);
+            if (s != this->zone_life.back())
+                this->zone_life.push_back(s);
+        }
+    }
+
+    void reset_stats() {
+        this->tracking = false;
+        this->zone_cnt = 0;
+        this->zone_life.clear();
+
+        this->round_cnt = 0;
+        this->pf_degree_sum = 0;
+        this->pf_degree_sqr_sum = 0;
+        this->max_score_le_sum = 0;
+        this->max_score_le_sqr_sum = 0;
+        this->max_score_ri_sum = 0;
+        this->max_score_ri_sqr_sum = 0;
+    }
+
+    void print_stats() {
+        cout << "[MLOP] History of tracked zone:" << endl;
+        for (auto &x : this->zone_life)
+            cout << x << endl;
+
+        double pf_degree_mean = 1.0 * this->pf_degree_sum / this->round_cnt;
+        double pf_degree_sqr_mean = 1.0 * this->pf_degree_sqr_sum / this->round_cnt;
+        double pf_degree_sd = sqrt(pf_degree_sqr_mean - square(pf_degree_mean));
+        cout << "[MLOP] Prefetch Degree Mean: " << pf_degree_mean << endl;
+        cout << "[MLOP] Prefetch Degree SD: " << pf_degree_sd << endl;
+
+        double max_score_le_mean = 1.0 * this->max_score_le_sum / this->round_cnt;
+        double max_score_le_sqr_mean = 1.0 * this->max_score_le_sqr_sum / this->round_cnt;
+        double max_score_le_sd = sqrt(max_score_le_sqr_mean - square(max_score_le_mean));
+        cout << "[MLOP] Max Score Left Mean (%): " << 100.0 * max_score_le_mean / NUM_UPDATES << endl;
+        cout << "[MLOP] Max Score Left SD (%): " << 100.0 * max_score_le_sd / NUM_UPDATES << endl;
+
+        double max_score_ri_mean = 1.0 * this->max_score_ri_sum / this->round_cnt;
+        double max_score_ri_sqr_mean = 1.0 * this->max_score_ri_sqr_sum / this->round_cnt;
+        double max_score_ri_sd = sqrt(max_score_ri_sqr_mean - square(max_score_ri_mean));
+        cout << "[MLOP] Max Score Right Mean (%): " << 100.0 * max_score_ri_mean / NUM_UPDATES << endl;
+        cout << "[MLOP] Max Score Right SD (%): " << 100.0 * max_score_ri_sd / NUM_UPDATES << endl;
+    }
+
+  private:
+    bool is_inside_zone(int zone_offset) { return (0 <= zone_offset && zone_offset < this->blocks_in_zone); }
+
+    const int PF_DEGREE;
+    const int NUM_UPDATES;
+    const int L1D_THRESH;
+    const int L2C_THRESH;
+    const int LLC_THRESH;
+    const int ORIGIN;
+    const int MAX_OFFSET;
+    const int NUM_OFFSETS;
+
+    int blocks_in_zone;
+    AccessMapTable access_map_table;
+
+    /**
+     * Contains best offsets for each degree of prefetching. A degree will have several offsets if
+     * they all had maximum score (thus, a vector of vectors). A degree won't have any offsets if
+     * all best offsets were redundant (already selected in previous degrees).
+     */
+    vector<vector<int>> pf_offset;
+
+    vector<vector<int>> offset_scores;
+    vector<int> pf_level; /* the prefetching level for each degree of prefetching offsets */
+    int update_cnt = 0;  /* tracks the number of score updates, round is over when `update_cnt == NUM_UPDATES` */
+
+    int debug_level = 0;
+
+    /* stats */
+    const uint64_t TRACKED_ZONE_CNT = 100;
+    bool tracking = false;
+    uint64_t tracked_zone_number = 0;
+    uint64_t zone_cnt = 0;
+    vector<string> zone_life;
+
+    uint64_t round_cnt = 0;
+    uint64_t pf_degree_sum = 0, pf_degree_sqr_sum = 0;
+    uint64_t max_score_le_sum = 0, max_score_le_sqr_sum = 0;
+    uint64_t max_score_ri_sum = 0, max_score_ri_sqr_sum = 0;
+
+    /*=======================================================*/
+    /*======== Storage required for `offset_scores` =========*/
+    /* pf_degree * (blocks_in_page - 1) * 2 * SCORE_BITS     */
+    /* 16 * (64 - 1) * 2 * 9 = 2268 Bytes                    */
+    /*=======================================================*/
+
+    /*=======================================================*/
+    /*=== Storage required for `pf_offsets` & `pf_levels` ===*/
+    /* (blocks_in_page - 1) * 2 * (FILL_BITS + OFFSET_BITS)  */
+    /* (64 - 1) * 2 * (1 + 6) = 882 Bits                     */
+    /*=======================================================*/
+};
+
+/**
+ * The global debug level. Higher values will print more information.
+ * NOTE: The size of the output file can become very large (~GBs).
+ */
+const int DEBUG_LEVEL = 0;
+
+vector<MLOP> prefetchers;
+}
+
+void CACHE::l1d_prefetcher_initialize() {
+    /*=== MLOP Settings ===*/
+    const int BLOCKS_IN_CACHE = CACHE::NUM_SET * CACHE::NUM_WAY;
+    const int BLOCKS_IN_ZONE = PAGE_SIZE / BLOCK_SIZE;
+    const int AMT_SIZE = 32 * BLOCKS_IN_CACHE / BLOCKS_IN_ZONE; /* size of access map table */
+
+    /* maximum possible prefetch degree (the actual prefetch degree is usually much smaller) */
+    const int PREFETCH_DEGREE = 16;
+
+    /* number of score updates before selecting prefetch offsets (thus, it is also the maximum possible score) */
+    const int NUM_UPDATES = 500;
+
+    /* prefetch offsets with `score >= LX_THRESH * NUM_UPDATES` into LX */
+    const double L1D_THRESH = 0.40; 
+    const double L2C_THRESH = 0.30;
+    const double LLC_THRESH = 2.00; /* off */
+    /*======================*/
+
+    /* construct prefetcher for all cores */
+    L1D_PREF_2::prefetchers =
+        vector<L1D_PREF_2::MLOP>(NUM_CPUS, L1D_PREF_2::MLOP(BLOCKS_IN_ZONE, AMT_SIZE, PREFETCH_DEGREE, NUM_UPDATES,
+                                              L1D_THRESH, L2C_THRESH, LLC_THRESH, L1D_PREF_2::DEBUG_LEVEL));
+}
+
+void CACHE::l1d_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint8_t critical_ip_flag)
+{
+    if (type != LOAD)
+        return;
+
+    uint64_t block_number = addr >> LOG2_BLOCK_SIZE;
+
+    /* check prefetch hit */
+    bool prefetch_hit = false;
+    if (cache_hit == 1) {
+        uint32_t set = get_set(block_number);
+        uint32_t way = get_way(block_number, set);
+        if (block[set][way].prefetch == 1)
+            prefetch_hit = true;
+    }
+
+    /* check trigger access */
+    bool trigger_access = false;
+    if (cache_hit == 0 || prefetch_hit)
+        trigger_access = true;
+
+    if (trigger_access)
+        /* update MLOP with most recent trigger access */
+        L1D_PREF_2::prefetchers[cpu].access(block_number);
+
+    /* issue prefetches */
+    L1D_PREF_2::prefetchers[cpu].mark(block_number, L1D_PREF_2::State::ACCESS);
+    L1D_PREF_2::prefetchers[cpu].prefetch(this, block_number);
+
+    if (L1D_PREF_2::DEBUG_LEVEL >= 3) {
+        L1D_PREF_2::prefetchers[cpu].log();
+        cerr << "=======================================" << dec << endl;
+    }
+
+    /* stats */
+    L1D_PREF_2::prefetchers[cpu].track(block_number);
+}
+
+void CACHE::l1d_prefetcher_cache_fill(uint64_t v_addr,uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t v_evicted_addr, uint64_t evicted_addr, uint32_t metadata_in)
+{
+    if (this->block[set][way].valid == 0)
+        return; /* no eviction */
+
+    uint64_t evicted_block_number = evicted_addr >> LOG2_BLOCK_SIZE;
+    L1D_PREF_2::prefetchers[cpu].mark(evicted_block_number, L1D_PREF_2::State::INIT);
+
+    /* stats */
+    L1D_PREF_2::prefetchers[cpu].track(evicted_block_number);
+}
+
+void CACHE::l1d_prefetcher_final_stats() {
+    cout << "=== CPU " << cpu << " L1D Prefetcher Statistics ===" << endl;
+    L1D_PREF_2::prefetchers[cpu].print_stats();
+}

--- a/src/prefetcher/champsim/csenv/next_line.l2c.inc
+++ b/src/prefetcher/champsim/csenv/next_line.l2c.inc
@@ -1,0 +1,29 @@
+#include "cache.h"
+
+void CACHE::l2c_prefetcher_initialize() 
+{
+    cout << "CPU " << cpu << " L2C next line prefetcher" << endl;
+}
+
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in, uint8_t critical_ip_flag)
+{
+    uint64_t pf_addr = ((addr>>LOG2_BLOCK_SIZE)+1) << LOG2_BLOCK_SIZE;
+
+    DP ( if (warmup_complete[cpu]) {
+    cout << "[" << NAME << "] " << __func__ << hex << " base_cl: " << (addr>>LOG2_BLOCK_SIZE);
+    cout << " pf_cl: " << (pf_addr>>LOG2_BLOCK_SIZE) << " ip: " << ip << " cache_hit: " << +cache_hit << " type: " << +type << endl; });
+
+    prefetch_line(ip, addr, pf_addr, FILL_L2, 0);
+
+    return metadata_in;
+}
+
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t way, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+  return metadata_in;
+}
+
+void CACHE::l2c_prefetcher_final_stats()
+{
+    cout << "CPU " << cpu << " L2C next line prefetcher final stats" << endl;
+}

--- a/src/prefetcher/champsim/csenv/ooo_cpu.h
+++ b/src/prefetcher/champsim/csenv/ooo_cpu.h
@@ -1,0 +1,19 @@
+/* Universal ChampSim shim: minimal fake of ChampSim's inc/ooo_cpu.h.
+ * Only the per-core retired-instruction fields a prefetcher reads (e.g. IPCP-L1
+ * computes MPKI = misses*1000/(num_retired - warmup_instructions)).
+ * Defined in champsim_shim.cc; num_retired is refreshed from Scarab's per-core
+ * retired counter inst_count[] via champsim::tick(). Included at GLOBAL scope by
+ * the wrapper so `ooo_cpu` resolves to the single global instance. */
+#ifndef OOO_CPU_H
+#define OOO_CPU_H
+
+#include "champsim.h"
+
+struct OOO_CPU {
+  uint64_t num_retired;
+  uint64_t warmup_instructions;
+};
+
+extern OOO_CPU ooo_cpu[NUM_CPUS];
+
+#endif  // OOO_CPU_H

--- a/src/prefetcher/champsim/csenv/spp.h
+++ b/src/prefetcher/champsim/csenv/spp.h
@@ -1,0 +1,160 @@
+#ifndef SPP_H
+#define SPP_H
+
+// SPP functional knobs
+#define LOOKAHEAD_ON
+#define FILTER_ON
+#define GHR_ON
+#define SPP_SANITY_CHECK
+
+//#define SPP_DEBUG_PRINT
+#ifdef SPP_DEBUG_PRINT
+#define SPP_DP(x) x
+#else
+#define SPP_DP(x)
+#endif
+
+// Signature table parameters
+#define ST_SET 1
+#define ST_WAY 256
+#define ST_TAG_BIT 16
+#define ST_TAG_MASK ((1 << ST_TAG_BIT) - 1)
+#define SIG_SHIFT 3
+#define SIG_BIT 12
+#define SIG_MASK ((1 << SIG_BIT) - 1)
+#define SIG_DELTA_BIT 7
+
+// Pattern table parameters
+#define PT_SET 512
+#define PT_WAY 4
+#define C_SIG_BIT 4
+#define C_DELTA_BIT 4
+#define C_SIG_MAX ((1 << C_SIG_BIT) - 1)
+#define C_DELTA_MAX ((1 << C_DELTA_BIT) - 1)
+
+// Prefetch filter parameters
+#define QUOTIENT_BIT  10
+#define REMAINDER_BIT 6
+#define HASH_BIT (QUOTIENT_BIT + REMAINDER_BIT + 1)
+#define FILTER_SET (1 << QUOTIENT_BIT)
+#define FILL_THRESHOLD 90
+#define PF_THRESHOLD 25
+
+// Global register parameters
+#define GLOBAL_COUNTER_BIT 10
+#define GLOBAL_COUNTER_MAX ((1 << GLOBAL_COUNTER_BIT) - 1) 
+#define MAX_GHR_ENTRY 8
+
+enum FILTER_REQUEST {SPP_L2C_PREFETCH, SPP_LLC_PREFETCH, L2C_DEMAND, L2C_EVICT}; // Request type for prefetch filter
+uint64_t get_hash(uint64_t key);
+
+class SIGNATURE_TABLE {
+  public:
+    bool     valid[ST_SET][ST_WAY];
+    uint32_t tag[ST_SET][ST_WAY],
+             last_offset[ST_SET][ST_WAY],
+             sig[ST_SET][ST_WAY],
+             lru[ST_SET][ST_WAY];
+
+    SIGNATURE_TABLE() {
+        cout << "Initialize SIGNATURE TABLE" << endl;
+        cout << "ST_SET: " << ST_SET << endl;
+        cout << "ST_WAY: " << ST_WAY << endl;
+        cout << "ST_TAG_BIT: " << ST_TAG_BIT << endl;
+        cout << "ST_TAG_MASK: " << hex << ST_TAG_MASK << dec << endl;
+
+        for (uint32_t set = 0; set < ST_SET; set++)
+            for (uint32_t way = 0; way < ST_WAY; way++) {
+                valid[set][way] = 0;
+                tag[set][way] = 0;
+                last_offset[set][way] = 0;
+                sig[set][way] = 0;
+                lru[set][way] = way;
+            }
+    };
+
+    void read_and_update_sig(uint64_t page, uint32_t page_offset, uint32_t &last_sig, uint32_t &curr_sig, int32_t &delta);
+};
+
+class PATTERN_TABLE {
+  public:
+    int      delta[PT_SET][PT_WAY];
+    uint32_t c_delta[PT_SET][PT_WAY],
+             c_sig[PT_SET];
+
+    PATTERN_TABLE() {
+        cout << endl << "Initialize PATTERN TABLE" << endl;
+        cout << "PT_SET: " << PT_SET << endl;
+        cout << "PT_WAY: " << PT_WAY << endl;
+        cout << "SIG_DELTA_BIT: " << SIG_DELTA_BIT << endl;
+        cout << "C_SIG_BIT: " << C_SIG_BIT << endl;
+        cout << "C_DELTA_BIT: " << C_DELTA_BIT << endl;
+
+        for (uint32_t set = 0; set < PT_SET; set++) {
+            for (uint32_t way = 0; way < PT_WAY; way++) {
+                delta[set][way] = 0;
+                c_delta[set][way] = 0;
+            }
+            c_sig[set] = 0;
+        }
+    }
+
+    void update_pattern(uint32_t last_sig, int curr_delta),
+         read_pattern(uint32_t curr_sig, int *prefetch_delta, uint32_t *confidence_q, uint32_t &lookahead_way, uint32_t &lookahead_conf, uint32_t &pf_q_tail, uint32_t &depth);
+};
+
+class PREFETCH_FILTER {
+  public:
+    uint64_t remainder_tag[FILTER_SET];
+    bool     valid[FILTER_SET],  // Consider this as "prefetched"
+             useful[FILTER_SET]; // Consider this as "used"
+
+    PREFETCH_FILTER() {
+        cout << endl << "Initialize PREFETCH FILTER" << endl;
+        cout << "FILTER_SET: " << FILTER_SET << endl;
+
+        for (uint32_t set = 0; set < FILTER_SET; set++) {
+            remainder_tag[set] = 0;
+            valid[set] = 0;
+            useful[set] = 0;
+        }
+
+    }
+
+    bool check(uint64_t pf_addr, FILTER_REQUEST filter_request);
+	bool add_to_filter(uint64_t pf_addr, FILTER_REQUEST filter_request);
+};
+
+class GLOBAL_REGISTER {
+  public:
+    // Global counters to calculate global prefetching accuracy
+    uint64_t pf_useful,
+             pf_issued,
+             global_accuracy; // Alpha value in Section III. Equation 3
+
+    // Global History Register (GHR) entries
+    uint8_t  valid[MAX_GHR_ENTRY];
+    uint32_t sig[MAX_GHR_ENTRY],
+             confidence[MAX_GHR_ENTRY],
+             offset[MAX_GHR_ENTRY];
+    int      delta[MAX_GHR_ENTRY];
+
+    GLOBAL_REGISTER() {
+        pf_useful = 0;
+        pf_issued = 0;
+        global_accuracy = 0;
+
+        for (uint32_t i = 0; i < MAX_GHR_ENTRY; i++) {
+            valid[i] = 0;
+            sig[i] = 0;
+            confidence[i] = 0;
+            offset[i] = 0;
+            delta[i] = 0;
+        }
+    }
+
+    void update_entry(uint32_t pf_sig, uint32_t pf_confidence, uint32_t pf_offset, int pf_delta);
+    uint32_t check_entry(uint32_t page_offset);
+};
+
+#endif

--- a/src/prefetcher/champsim/csenv/spp.l2c.inc
+++ b/src/prefetcher/champsim/csenv/spp.l2c.inc
@@ -1,0 +1,767 @@
+#include "cache.h"
+#include "spp.h"
+
+SIGNATURE_TABLE ST;
+PATTERN_TABLE   PT;
+PREFETCH_FILTER FILTER;
+GLOBAL_REGISTER GHR;
+int depth_track[30];
+int filter_skip;
+int depth_lost_at_filter[30];
+int depth_lost_at_page[30];
+int prefetch_q_full;
+
+//Neelu: Access counters for all tables and a warmup flag for l2
+uint64_t ST_read_accesses = 0, ST_write_accesses = 0, PT_read_accesses = 0, PT_write_accesses = 0, FILTER_read_accesses = 0, FILTER_write_accesses = 0, GHR_read_accesses = 0, GHR_write_accesses = 0, GHR_counter_read_accesses = 0, GHR_counter_write_accesses = 0;
+uint64_t ST_tag_read_accesses = 0, ST_tag_write_accesses = 0;
+uint8_t warmup_flag_l2 = 0;
+
+uint64_t critical_calls = 0, all_calls = 0;
+
+//#define CRITICAL_IP_L2_PREF
+
+void CACHE::l2c_prefetcher_initialize() 
+{
+	for(int a = 0; a < 30; a++)
+		depth_track[a] = 0;
+
+	prefetch_q_full = 0;
+
+	cout << "ST_WAYS: " << ST_WAY << endl;
+	cout << "PT_SETS: " << PT_SET << endl;
+
+//	overlapping_pref_req[cpu] = 0; 
+
+}
+
+uint32_t CACHE::l2c_prefetcher_operate(uint64_t addr, uint64_t ip, uint8_t cache_hit, uint8_t type, uint32_t metadata_in, uint8_t critical_ip_flag)
+{
+	all_calls++;
+#ifdef CRITICAL_IP_L2_PREF
+	if(!critical_ip_flag)
+		return metadata_in;
+#endif
+
+	critical_calls++;
+	//Neelu: Resetting counters after warmup complete
+	if(warmup_flag_l2 == 0 && warmup_complete[cpu])
+	{
+		ST_read_accesses = 0;
+		ST_write_accesses = 0; 
+		PT_read_accesses = 0; 
+		PT_write_accesses = 0; 
+		FILTER_read_accesses = 0; 
+		FILTER_write_accesses = 0;
+		GHR_read_accesses = 0; 
+		GHR_write_accesses = 0;
+		GHR_counter_read_accesses = 0;
+		GHR_counter_write_accesses = 0;
+		ST_tag_read_accesses = 0;
+                ST_tag_write_accesses = 0;
+		warmup_flag_l2 = 1;
+	}
+
+    uint64_t page = addr >> LOG2_PAGE_SIZE;
+    uint32_t page_offset = (addr >> LOG2_BLOCK_SIZE) & (PAGE_SIZE / BLOCK_SIZE - 1),
+             last_sig = 0,
+             curr_sig = 0,
+
+             confidence_q[L2C_MSHR_SIZE],
+             depth = 0;
+
+    int32_t  delta = 0,
+             delta_q[L2C_MSHR_SIZE]; 
+
+    for (uint32_t i = 0; i < L2C_MSHR_SIZE; i++){
+        confidence_q[i] = 0;
+        delta_q[i] = 0;
+    }
+    confidence_q[0] = 100;	
+    
+	//Neelu: Incrementing GHR write accesses
+        GHR_counter_write_accesses++;
+	//Neelu: Incrementing GHR read accesses
+        GHR_counter_read_accesses+=2; //for pf_useful and pf_issued
+	GHR.global_accuracy = GHR.pf_issued ? ((100 * GHR.pf_useful) / GHR.pf_issued)  : 0;
+    
+    SPP_DP (
+        cout << endl << "[ChampSim] " << __func__ << " addr: " << hex << addr << " cache_line: " << (addr >> LOG2_BLOCK_SIZE);
+        cout << " page: " << page << " page_offset: " << dec << page_offset << endl;
+    );
+
+    // Stage 1: Read and update a sig stored in ST
+    // last_sig and delta are used to update (sig, delta) correlation in PT
+    // curr_sig is used to read prefetch candidates in PT 
+    ST.read_and_update_sig(page, page_offset, last_sig, curr_sig, delta);
+
+    // Also check the prefetch filter in parallel to update global accuracy counters 
+    FILTER.check(addr, L2C_DEMAND); 
+
+    // Stage 2: Update delta patterns stored in PT
+    if (last_sig) PT.update_pattern(last_sig, delta);
+
+    // Stage 3: Start prefetching
+    uint64_t base_addr = addr;
+    uint32_t lookahead_conf = 100,
+             pf_q_head = 0, 
+             pf_q_tail = 0;
+    uint8_t  do_lookahead = 0;
+
+#ifdef LOOKAHEAD_ON
+    do {
+#endif
+        uint32_t lookahead_way = PT_WAY;
+        PT.read_pattern(curr_sig, delta_q, confidence_q, lookahead_way, lookahead_conf, pf_q_tail, depth);
+
+        do_lookahead = 0;
+        for (uint32_t i = pf_q_head; i < pf_q_tail; i++) {
+            if (confidence_q[i] >= PF_THRESHOLD) {
+                uint64_t pf_addr = (base_addr & ~(BLOCK_SIZE - 1)) + (delta_q[i] << LOG2_BLOCK_SIZE);
+
+                if ((addr & ~(PAGE_SIZE - 1)) == (pf_addr & ~(PAGE_SIZE - 1))) { // Prefetch request is in the same physical page
+                    if (FILTER.check(pf_addr, ((confidence_q[i] >= FILL_THRESHOLD) ? SPP_L2C_PREFETCH : SPP_LLC_PREFETCH))) {
+		    
+						if(prefetch_line(ip, addr, pf_addr, ((confidence_q[i] >= FILL_THRESHOLD) ? FILL_L2 : FILL_LLC), 0)){ // Use addr (not base_addr) to obey the same physical page boundary
+							depth_track[depth]++;
+							FILTER.add_to_filter(pf_addr, ((confidence_q[i] >= FILL_THRESHOLD) ? SPP_L2C_PREFETCH : SPP_LLC_PREFETCH));
+						}else{
+							prefetch_q_full++;
+						}
+
+                        if (confidence_q[i] >= FILL_THRESHOLD) {
+				//Neelu: Incrementing GHR write accesses
+		                GHR_counter_write_accesses++;
+                            GHR.pf_issued++;	//global issued incremented if filled in L2.
+                            if (GHR.pf_issued > GLOBAL_COUNTER_MAX) {
+                                GHR.pf_issued >>= 1;
+				GHR_counter_write_accesses++;
+                                GHR.pf_useful >>= 1;
+                            }
+                            SPP_DP (cout << "[ChampSim] SPP L2 prefetch issued GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << endl;);
+                        }
+
+                        SPP_DP (
+                            cout << "[ChampSim] " << __func__ << " base_addr: " << hex << base_addr << " pf_addr: " << pf_addr;
+                            cout << " pf_cache_line: " << (pf_addr >> LOG2_BLOCK_SIZE);
+                            cout << " prefetch_delta: " << dec << delta_q[i] << " confidence: " << confidence_q[i];
+                            cout << " depth: " << i << " fill_level: " << ((confidence_q[i] >= FILL_THRESHOLD) ? FILL_L2 : FILL_LLC) << endl;
+                        );
+                    }else{ 	//So here, the depth frequency is tracked. 
+						depth_lost_at_filter[depth]++;
+					}
+                } else { // Prefetch request is crossing the physical page boundary
+#ifdef GHR_ON
+                    // Store this prefetch request in GHR to bootstrap SPP learning when we see a ST miss (i.e., accessing a new page)
+                    GHR.update_entry(curr_sig, confidence_q[i], (pf_addr >> LOG2_BLOCK_SIZE) & 0x3F, delta_q[i]); 
+#endif
+					depth_lost_at_page[depth]++;
+                }
+
+                do_lookahead = 1;
+                pf_q_head++;
+            }
+        }
+
+        // Update base_addr and curr_sig
+        if (lookahead_way < PT_WAY) {
+
+		//Neelu: Incrementing PT read accesses, reading lookahead_way entry again for lookahead. Can it be avoided? I am considering it for now.
+                PT_read_accesses++;
+
+            uint32_t set = get_hash(curr_sig) % PT_SET;
+            base_addr += (PT.delta[set][lookahead_way] << LOG2_BLOCK_SIZE);
+
+            // PT.delta uses a 7-bit sign magnitude representation to generate sig_delta
+            //int sig_delta = (PT.delta[set][lookahead_way] < 0) ? ((((-1) * PT.delta[set][lookahead_way]) & 0x3F) + 0x40) : PT.delta[set][lookahead_way];
+            int sig_delta = (PT.delta[set][lookahead_way] < 0) ? (((-1) * PT.delta[set][lookahead_way]) + (1 << (SIG_DELTA_BIT - 1))) : PT.delta[set][lookahead_way];
+            curr_sig = ((curr_sig << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
+        }
+
+        SPP_DP (
+            cout << "Looping curr_sig: " << hex << curr_sig << " base_addr: " << base_addr << dec;
+            cout << " pf_q_head: " << pf_q_head << " pf_q_tail: " << pf_q_tail << " depth: " << depth << endl;
+        );
+#ifdef LOOKAHEAD_ON
+    } while (do_lookahead);
+#endif
+
+    return metadata_in;
+}
+
+uint32_t CACHE::l2c_prefetcher_cache_fill(uint64_t addr, uint32_t set, uint32_t match, uint8_t prefetch, uint64_t evicted_addr, uint32_t metadata_in)
+{
+#ifdef FILTER_ON
+    SPP_DP (cout << endl;);
+    FILTER.check(evicted_addr, L2C_EVICT);
+#endif
+
+    return metadata_in;
+}
+
+void CACHE::l2c_prefetcher_final_stats()
+{
+	cout << " All Calls: " << all_calls << endl;
+	cout << " Critical Calls: " << critical_calls << endl;
+	int tot = 0;
+	printf("------------------\n");
+	printf("Depth Distribution\n");
+	printf("------------------\n");
+	for(int a = 0; a < 30; a++){
+		printf("depth %d: %d\n", a, depth_track[a]);
+		tot += depth_track[a];
+	}
+	printf("Total: %d\n", tot);
+	printf("-----------------------------\n");
+	printf("-----------------------------\n");
+	printf("	Captured at Filter\n");
+	printf("-----------------------------\n");
+	for(int a = 0; a < 30; a++){
+		printf("depth %d: %d\n", a, depth_lost_at_filter[a]);
+	}
+	printf("-----------------------------\n");
+	printf("-----------------------------\n");
+	printf("		Lost at Page\n");
+	printf("-----------------------------\n");
+	for(int a = 0; a < 30; a++){
+		printf("depth %d: %d\n", a, depth_lost_at_page[a]);
+	}
+	printf("-----------------------------\n");
+	printf("-----------------------------\n");
+	printf("	Lost due to PQ Size\n");
+	printf("-----------------------------\n");
+	printf("%d\n", prefetch_q_full);
+	printf("-----------------------------\n");
+
+
+	//Neelu: Printing Access Stats
+	cout << "ST read accesses: " << ST_read_accesses << endl;
+        cout << "ST write accesses: " << ST_write_accesses << endl;
+	cout << "PT read accesses: " << PT_read_accesses << endl;
+        cout << "PT write accesses: " << PT_write_accesses << endl;
+	cout << "FILTER read accesses: " << FILTER_read_accesses << endl;
+        cout << "FILTER write accesses: " << FILTER_write_accesses << endl;
+	cout << "GHR read accesses: " << GHR_read_accesses << endl;
+        cout << "GHR write accesses: " << GHR_write_accesses << endl;
+	cout << "GHR counter read accesses: " << GHR_counter_read_accesses << endl;
+	cout << "GHR counter write accesses: " << GHR_counter_write_accesses << endl;
+	cout << "ST tag read accesses: " << ST_tag_read_accesses << endl;
+        cout << "ST tag write accesses: " << ST_tag_write_accesses << endl;
+
+}
+
+// TODO: Find a good 64-bit hash function
+uint64_t get_hash(uint64_t key)
+{
+    // Robert Jenkins' 32 bit mix function
+    key += (key << 12);
+    key ^= (key >> 22);
+    key += (key << 4);
+    key ^= (key >> 9);
+    key += (key << 10);
+    key ^= (key >> 2);
+    key += (key << 7);
+    key ^= (key >> 12);
+
+    // Knuth's multiplicative method
+    key = (key >> 3) * 2654435761;
+
+    return key;
+}
+
+void SIGNATURE_TABLE::read_and_update_sig(uint64_t page, uint32_t page_offset, uint32_t &last_sig, uint32_t &curr_sig, int32_t &delta)
+{
+    uint32_t set = get_hash(page) % ST_SET, 	//To index into the ST. 
+             match = ST_WAY,
+             partial_page = page & ST_TAG_MASK;	//Using partial tag in the ST.
+    uint8_t  ST_hit = 0;
+    int      sig_delta = 0;
+
+    SPP_DP (cout << "[ST] " << __func__ << " page: " << hex << page << " partial_page: " << partial_page << dec << endl;);
+
+    // Case 1: Hit
+    for (match = 0; match < ST_WAY; match++) {
+
+	//Neelu: Incrementing ST read accesses
+	ST_tag_read_accesses++;
+
+        if (valid[set][match] && (tag[set][match] == partial_page)) {
+	    ST_read_accesses++;
+            last_sig = sig[set][match];
+            delta = page_offset - last_offset[set][match];
+
+            if (delta) {	//N As in if it's not called for the same line, right?  Yes.
+                // Build a new sig based on 7-bit sign magnitude representation of delta
+                //sig_delta = (delta < 0) ? ((((-1) * delta) & 0x3F) + 0x40) : delta;
+                sig_delta = (delta < 0) ? (((-1) * delta) + (1 << (SIG_DELTA_BIT - 1))) : delta;
+                sig[set][match] = ((last_sig << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
+                curr_sig = sig[set][match];
+                last_offset[set][match] = page_offset;
+
+                SPP_DP (
+                    cout << "[ST] " << __func__ << " hit set: " << set << " way: " << match;
+                    cout << " valid: " << valid[set][match] << " tag: " << hex << tag[set][match];
+                    cout << " last_sig: " << last_sig << " curr_sig: " << curr_sig;
+                    cout << " delta: " << dec << delta << " last_offset: " << page_offset << endl;
+                );
+            } else last_sig = 0; // Hitting the same cache line, delta is zero
+
+            ST_hit = 1;
+            break;
+        }
+    }
+
+    // Case 2: Invalid //N MISS and looking for invalid.
+    if (match == ST_WAY) {
+        for (match = 0; match < ST_WAY; match++) {
+		//Neelu: Incrementing ST read accesses
+        	ST_tag_read_accesses++;
+            if (valid[set][match] == 0) {
+		//Neelu: Incrementing ST write accesses
+        	ST_write_accesses++;
+                valid[set][match] = 1;
+                tag[set][match] = partial_page;
+                sig[set][match] = 0;	//N Why zero? Why not XOR current delta in this? 
+                curr_sig = sig[set][match];
+                last_offset[set][match] = page_offset;
+
+                SPP_DP (
+                    cout << "[ST] " << __func__ << " invalid set: " << set << " way: " << match;
+                    cout << " valid: " << valid[set][match] << " tag: " << hex << partial_page;
+                    cout << " sig: " << sig[set][match] << " last_offset: " << dec << page_offset << endl;
+                );
+
+                break;
+            }
+        }
+    }
+
+    // Case 3: Miss	//N Miss and no invalid
+    if (match == ST_WAY) {
+        for (match = 0; match < ST_WAY; match++) {
+		//Neelu: Incrementing ST read accesses
+        	ST_tag_read_accesses++;
+            if (lru[set][match] == ST_WAY - 1) { // Find replacement victim
+		//Neelu: Incrementing ST write accesses
+        	ST_write_accesses++;
+
+                tag[set][match] = partial_page;
+                sig[set][match] = 0;
+                curr_sig = sig[set][match];
+                last_offset[set][match] = page_offset;
+
+                SPP_DP (
+                    cout << "[ST] " << __func__ << " miss set: " << set << " way: " << match;
+                    cout << " valid: " << valid[set][match] << " victim tag: " << hex << tag[set][match] << " new tag: " << partial_page;
+                    cout << " sig: " << sig[set][match] << " last_offset: " << dec << page_offset << endl;
+                );
+
+                break;
+            }
+        }
+
+        #ifdef SPP_SANITY_CHECK
+        // Assertion
+        if (match == ST_WAY) {
+            cout << "[ST] Cannot find a replacement victim!" << endl;
+            assert(0);
+        }
+        #endif
+    }
+//N So basically this function, when a page misses in the ST, creates a new entry, no learning in this iteration except if a corresponding entry is present in the GHR. 
+#ifdef GHR_ON
+    if (ST_hit == 0) {
+        uint32_t GHR_found = GHR.check_entry(page_offset);
+        if (GHR_found < MAX_GHR_ENTRY) {
+	
+		//Neelu: Incrementing GHR read accesses. ST write can be considered a part of the writes above, so not incrementing here. 
+		GHR_read_accesses++;
+
+            sig_delta = (GHR.delta[GHR_found] < 0) ? (((-1) * GHR.delta[GHR_found]) + (1 << (SIG_DELTA_BIT - 1))) : GHR.delta[GHR_found];
+            sig[set][match] = ((GHR.sig[GHR_found] << SIG_SHIFT) ^ sig_delta) & SIG_MASK;
+            curr_sig = sig[set][match];
+        }
+    }
+#endif
+
+    // Update LRU
+    for (uint32_t way = 0; way < ST_WAY; way++) {
+	//Neelu: Incrementing ST read accesses
+        ST_tag_read_accesses++;
+        if (lru[set][way] < lru[set][match]) {
+            lru[set][way]++;
+	
+		//Neelu: Incrementing ST write accesses
+        	ST_tag_write_accesses++;
+
+            #ifdef SPP_SANITY_CHECK
+            // Assertion
+            if (lru[set][way] >= ST_WAY) {
+                cout << "[ST] LRU value is wrong! set: " << set << " way: " << way << " lru: " << lru[set][way] << endl;
+                assert(0);
+            }
+            #endif
+        }
+    }
+    ST_tag_write_accesses++;
+    lru[set][match] = 0; // Promote to the MRU position
+}
+
+void PATTERN_TABLE::update_pattern(uint32_t last_sig, int curr_delta)
+{
+    // Update (sig, delta) correlation
+    uint32_t set = get_hash(last_sig) % PT_SET,
+             match = 0;
+
+    // Case 1: Hit
+    for (match = 0; match < PT_WAY; match++) {
+	//Neelu: Incrementing PT read accesses
+        PT_read_accesses++;
+        if (delta[set][match] == curr_delta) {
+		//Neelu: Incrementing PT write accesses
+        	PT_write_accesses++;
+            c_delta[set][match]++;
+            c_sig[set]++;
+            if (c_sig[set] > C_SIG_MAX) {
+		//Neelu: Incrementing PT write accesses, writing all ways
+        	PT_write_accesses += PT_WAY;
+
+                for (uint32_t way = 0; way < PT_WAY; way++)
+                    c_delta[set][way] >>= 1;
+                c_sig[set] >>= 1;
+            }
+
+            SPP_DP (
+                cout << "[PT] " << __func__ << " hit sig: " << hex << last_sig << dec << " set: " << set << " way: " << match;
+                cout << " delta: " << delta[set][match] << " c_delta: " << c_delta[set][match] << " c_sig: " << c_sig[set] << endl;
+            );
+
+            break;
+        }
+    }
+
+    // Case 2: Miss
+    if (match == PT_WAY) {
+        uint32_t victim_way = PT_WAY,
+                 min_counter = C_SIG_MAX;
+
+        for (match = 0; match < PT_WAY; match++) {
+		//Neelu: Incrementing PT read accesses
+        	PT_read_accesses++;
+            if (c_delta[set][match] < min_counter) { // Select an entry with the minimum c_delta
+                victim_way = match;
+                min_counter = c_delta[set][match];
+            }
+        }
+
+	//Neelu: Incrementing PT write accesses
+        PT_write_accesses++;
+
+        delta[set][victim_way] = curr_delta;
+        c_delta[set][victim_way] = 0; 	//N DOUBT c_delta = 0, but c_sig++, how does that even make sense? 
+        c_sig[set]++;
+        if (c_sig[set] > C_SIG_MAX) {
+		//Neelu: Incrementing PT write accesses for all ways
+        	PT_write_accesses += PT_WAY;
+            for (uint32_t way = 0; way < PT_WAY; way++)
+                c_delta[set][way] >>= 1;
+            c_sig[set] >>= 1;
+        }
+
+        SPP_DP (
+            cout << "[PT] " << __func__ << " miss sig: " << hex << last_sig << dec << " set: " << set << " way: " << victim_way;
+            cout << " delta: " << delta[set][victim_way] << " c_delta: " << c_delta[set][victim_way] << " c_sig: " << c_sig[set] << endl;
+        );
+
+        #ifdef SPP_SANITY_CHECK
+        // Assertion
+        if (victim_way == PT_WAY) {
+            cout << "[PT] Cannot find a replacement victim!" << endl;
+            assert(0);
+        }
+        #endif
+    }
+}
+
+void PATTERN_TABLE::read_pattern(uint32_t curr_sig, int *delta_q, uint32_t *confidence_q, uint32_t &lookahead_way, uint32_t &lookahead_conf, uint32_t &pf_q_tail, uint32_t &depth)
+{
+    // Update (sig, delta) correlation
+    uint32_t set = get_hash(curr_sig) % PT_SET,
+             local_conf = 0,
+             pf_conf = 0,
+             max_conf = 0;
+
+    if (c_sig[set]) {
+        for (uint32_t way = 0; way < PT_WAY; way++) {
+
+		//Neelu: Incrementing PT and GHR read accesses
+		PT_read_accesses++;
+		GHR_counter_read_accesses++;
+            local_conf = (100 * c_delta[set][way]) / c_sig[set];
+            pf_conf = depth ? (GHR.global_accuracy * c_delta[set][way] / c_sig[set] * lookahead_conf / 100) : local_conf;
+
+            if (pf_conf >= PF_THRESHOLD) {
+                confidence_q[pf_q_tail] = pf_conf;
+                delta_q[pf_q_tail] = delta[set][way];
+
+                // Lookahead path follows the most confident entry
+                if (pf_conf > max_conf) {
+                    lookahead_way = way;
+                    max_conf = pf_conf;
+                }
+                pf_q_tail++;
+
+                SPP_DP (
+                    cout << "[PT] " << __func__ << " HIGH CONF: " << pf_conf << " sig: " << hex << curr_sig << dec << " set: " << set << " way: " << way;
+                    cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+                    cout << " conf: " << local_conf << " depth: " << depth << endl;
+                );
+            } else {
+                SPP_DP (
+                    cout << "[PT] " << __func__ << "  LOW CONF: " << pf_conf << " sig: " << hex << curr_sig << dec << " set: " << set << " way: " << way;
+                    cout << " delta: " << delta[set][way] << " c_delta: " << c_delta[set][way] << " c_sig: " << c_sig[set];
+                    cout << " conf: " << local_conf << " depth: " << depth << endl;
+                );
+            }
+        }
+        lookahead_conf = max_conf;
+        if (lookahead_conf >= PF_THRESHOLD) depth++;
+
+        SPP_DP (cout << "global_accuracy: " << GHR.global_accuracy << " lookahead_conf: " << lookahead_conf << endl;);
+    } else confidence_q[pf_q_tail] = 0;
+}
+
+bool PREFETCH_FILTER::add_to_filter(uint64_t check_addr, FILTER_REQUEST filter_request){
+	uint64_t cache_line = check_addr >> LOG2_BLOCK_SIZE,
+             hash = get_hash(cache_line),
+             quotient = (hash >> REMAINDER_BIT) & ((1 << QUOTIENT_BIT) - 1),
+             remainder = hash % (1 << REMAINDER_BIT);
+
+	switch (filter_request) {
+		case SPP_L2C_PREFETCH:
+	                //Neelu: Incrementing FILTER write accesses
+	                FILTER_write_accesses++;
+		
+			valid[quotient] = 1;  // Mark as prefetched
+			useful[quotient] = 0; // Reset useful bit
+			remainder_tag[quotient] = remainder;
+
+			SPP_DP (
+				cout << "[FILTER] " << __func__ << " set valid for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+				cout << " quotient: " << quotient << " remainder_tag: " << remainder_tag[quotient] << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+			);
+            break;
+
+        case SPP_LLC_PREFETCH:
+			// NOTE: SPP_LLC_PREFETCH has relatively low confidence (FILL_THRESHOLD <= SPP_LLC_PREFETCH < PF_THRESHOLD) 
+			// Therefore, it is safe to prefetch this cache line in the large LLC and save precious L2C capacity
+			// If this prefetch request becomes more confident and SPP eventually issues SPP_L2C_PREFETCH,
+			// we can get this cache line immediately from the LLC (not from DRAM)
+			// To allow this fast prefetch from LLC, SPP does not set the valid bit for SPP_LLC_PREFETCH
+
+			//valid[quotient] = 1;
+			//useful[quotient] = 0;
+
+			SPP_DP (
+				cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+				cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+			);
+            break;
+		default:
+            cout << "[FILTER] Invalid filter request type: " << filter_request << endl;
+            assert(0);
+	}
+	return true;
+}
+
+bool PREFETCH_FILTER::check(uint64_t check_addr, FILTER_REQUEST filter_request)
+{
+    uint64_t cache_line = check_addr >> LOG2_BLOCK_SIZE,
+             hash = get_hash(cache_line),
+             quotient = (hash >> REMAINDER_BIT) & ((1 << QUOTIENT_BIT) - 1),
+             remainder = hash % (1 << REMAINDER_BIT);
+
+    SPP_DP (
+        cout << "[FILTER] check_addr: " << hex << check_addr << " check_cache_line: " << (check_addr >> LOG2_BLOCK_SIZE);
+        cout << " hash: " << hash << dec << " quotient: " << quotient << " remainder: " << remainder << endl;
+    );
+
+    switch (filter_request) {
+        case SPP_L2C_PREFETCH:
+		//Neelu: Incrementing FILTER read accesses
+                FILTER_read_accesses++;
+            if ((valid[quotient] || useful[quotient]) && remainder_tag[quotient] == remainder) { 
+                SPP_DP (
+                    cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+                    cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+                );
+
+                return false; // False return indicates "Do not prefetch"
+            } 
+			//else {
+            //    valid[quotient] = 1;  // Mark as prefetched
+            //    useful[quotient] = 0; // Reset useful bit
+            //    remainder_tag[quotient] = remainder;
+
+            //    SPP_DP (
+            //        cout << "[FILTER] " << __func__ << " set valid for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+            //        cout << " quotient: " << quotient << " remainder_tag: " << remainder_tag[quotient] << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+            //    );
+            //}
+            break;
+
+        case SPP_LLC_PREFETCH:
+		//Neelu: Incrementing FILTER read accesses
+                FILTER_read_accesses++;
+            if ((valid[quotient] || useful[quotient]) && remainder_tag[quotient] == remainder) { 
+                SPP_DP (
+                    cout << "[FILTER] " << __func__ << " line is already in the filter check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+                    cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+                );
+
+                return false; // False return indicates "Do not prefetch"
+            } else {
+                // NOTE: SPP_LLC_PREFETCH has relatively low confidence (FILL_THRESHOLD <= SPP_LLC_PREFETCH < PF_THRESHOLD) 
+                // Therefore, it is safe to prefetch this cache line in the large LLC and save precious L2C capacity
+                // If this prefetch request becomes more confident and SPP eventually issues SPP_L2C_PREFETCH,
+                // we can get this cache line immediately from the LLC (not from DRAM)
+                // To allow this fast prefetch from LLC, SPP does not set the valid bit for SPP_LLC_PREFETCH
+
+                //valid[quotient] = 1;
+                //useful[quotient] = 0;
+
+                SPP_DP (
+                    cout << "[FILTER] " << __func__ << " don't set valid for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+                    cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient] << endl; 
+                );
+            }
+            break;
+
+        case L2C_DEMAND:
+		//Neelu: Incrementing FILTER read accesses
+                FILTER_read_accesses++;
+            if ((remainder_tag[quotient] == remainder) && (useful[quotient] == 0)) {
+		//Neelu: Incrementing FILTER write accesses
+                FILTER_write_accesses++;
+                useful[quotient] = 1;
+                if (valid[quotient])
+		{
+			//Neelu: Incrementing GHR write accesses
+	                GHR_counter_write_accesses++;
+			GHR.pf_useful++; // This cache line was prefetched by SPP and actually used in the program
+		}
+
+                SPP_DP (
+                    cout << "[FILTER] " << __func__ << " set useful for check_addr: " << hex << check_addr << " cache_line: " << cache_line << dec;
+                    cout << " quotient: " << quotient << " valid: " << valid[quotient] << " useful: " << useful[quotient];
+                    cout << " GHR.pf_issued: " << GHR.pf_issued << " GHR.pf_useful: " << GHR.pf_useful << endl; 
+                );
+            }
+            break;
+
+        case L2C_EVICT:
+		//Neelu: Incrementing FILTER read accesses
+                FILTER_read_accesses++;
+                //Neelu: Incrementing FILTER write accesses
+                FILTER_write_accesses++;
+            // Decrease global pf_useful counter when there is a useless prefetch (prefetched but not used)
+            if (valid[quotient] && !useful[quotient] && GHR.pf_useful)
+	    {
+		//Neelu: Incrementing GHR write accesses
+                GHR_counter_write_accesses++;
+		GHR.pf_useful--;
+	    }
+
+            // Reset filter entry
+            valid[quotient] = 0;
+            useful[quotient] = 0;
+            remainder_tag[quotient] = 0;
+            break;
+
+        default:
+            // Assertion
+            cout << "[FILTER] Invalid filter request type: " << filter_request << endl;
+            assert(0);
+    }
+
+    return true;
+}
+
+void GLOBAL_REGISTER::update_entry(uint32_t pf_sig, uint32_t pf_confidence, uint32_t pf_offset, int pf_delta) 
+{
+    // NOTE: GHR implementation is slightly different from the original paper
+    // Instead of matching (last_offset + delta), GHR simply stores and matches the pf_offset
+    uint32_t min_conf = 100,
+             victim_way = MAX_GHR_ENTRY;
+
+    SPP_DP (
+        cout << "[GHR] Crossing the page boundary pf_sig: " << hex << pf_sig << dec;
+        cout << " confidence: " << pf_confidence << " pf_offset: " << pf_offset << " pf_delta: " << pf_delta << endl;
+    );
+
+    for (uint32_t i = 0; i < MAX_GHR_ENTRY; i++) {
+	//Neelu: Incrementing GHR read accesses
+        GHR_read_accesses++;
+
+        //if (sig[i] == pf_sig) { // TODO: Which one is better and consistent?
+            // If GHR already holds the same pf_sig, update the GHR entry with the latest info
+        if (valid[i] && (offset[i] == pf_offset)) {
+		//Neelu: Incrementing GHR write accesses
+                GHR_write_accesses++;
+            // If GHR already holds the same pf_offset, update the GHR entry with the latest info
+            sig[i] = pf_sig;
+            confidence[i] = pf_confidence;
+            //offset[i] = pf_offset;
+            delta[i] = pf_delta;
+
+            SPP_DP (cout << "[GHR] Found a matching index: " << i << endl;);
+
+            return;
+        }
+
+        // GHR replacement policy is based on the stored confidence value
+        // An entry with the lowest confidence is selected as a victim
+        if (confidence[i] < min_conf) {
+            min_conf = confidence[i];
+            victim_way = i;
+        }
+    }
+
+    // Assertion
+    if (victim_way >= MAX_GHR_ENTRY) {
+        cout << "[GHR] Cannot find a replacement victim!" << endl;
+        assert(0);
+    }
+
+    SPP_DP (
+        cout << "[GHR] Replace index: " << victim_way << " pf_sig: " << hex << sig[victim_way] << dec;
+        cout << " confidence: " << confidence[victim_way] << " pf_offset: " << offset[victim_way] << " pf_delta: " << delta[victim_way] << endl;
+    );
+
+	//Neelu: Incrementing GHR write accesses
+        GHR_write_accesses++;
+
+    valid[victim_way] = 1;
+    sig[victim_way] = pf_sig;
+    confidence[victim_way] = pf_confidence;
+    offset[victim_way] = pf_offset;
+    delta[victim_way] = pf_delta;
+}
+
+uint32_t GLOBAL_REGISTER::check_entry(uint32_t page_offset)
+{
+	//N Looking for the entry with same offset and max confidence. 
+    uint32_t max_conf = 0,
+             max_conf_way = MAX_GHR_ENTRY;
+
+	//Neelu: Incrementing GHR read accesses
+                GHR_read_accesses+=MAX_GHR_ENTRY;
+
+    for (uint32_t i = 0; i < MAX_GHR_ENTRY; i++) {
+        if ((offset[i] == page_offset) && (max_conf < confidence[i])) {
+            max_conf = confidence[i];
+            max_conf_way = i;
+        }
+    }
+
+    return max_conf_way;
+}

--- a/src/prefetcher/champsim/pref_champsim.h
+++ b/src/prefetcher/champsim/pref_champsim.h
@@ -1,0 +1,91 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/***************************************************************************************
+ * File         : prefetcher/champsim/pref_champsim.h
+ * Description  : Declarations of the Scarab hooks exported by ChampSim-shim
+ *                prefetcher wrappers. Included by pref_common.c before pref_table.def.
+ ***************************************************************************************/
+#ifndef __PREF_CHAMPSIM_H__
+#define __PREF_CHAMPSIM_H__
+
+#include "globals/global_types.h"
+
+#include "prefetcher/pref_common.h"
+
+/* --- MLOP (vendor mlop_dpc3.l1d). ONE entry; enable by listing TYPE_MLOP in
+ *     exactly one of --pref_{dcache,mlc,l1}_prefetchers with its DEST_* token.
+ *     Multi-fill-level with --pref_mlop_route_by_fill 1. DL0 hooks take
+ *     (lineAddr, loadPC). --- */
+void pref_mlop_init(HWP* hwp);
+void pref_mlop_per_core_done(uns proc_id);
+void pref_mlop_dl0_miss(Addr lineAddr, Addr loadPC);
+void pref_mlop_dl0_hit(Addr lineAddr, Addr loadPC);
+void pref_mlop_dl0_pref_hit(Addr lineAddr, Addr loadPC);
+void pref_mlop_mlc_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_mlop_mlc_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_mlop_mlc_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_mlop_l1_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_mlop_l1_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_mlop_l1_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+
+/* --- IPCP (self-contained vendor ipcp_isca2020.l1d). ONE entry; enable by listing
+ *     TYPE_IPCP in exactly one of --pref_{dcache,mlc,l1}_prefetchers with its DEST_*
+ *     token (Scarab names: dcache=L1D/DL0, mlc=L2/UMLC, l1=LLC/UL1). The entry
+ *     carries hooks for all three levels; the dispatchers only fire the listed
+ *     training level's hooks. DL0 hooks take (lineAddr, loadPC). --- */
+void pref_ipcp_init(HWP* hwp);
+void pref_ipcp_per_core_done(uns proc_id);
+void pref_ipcp_dl0_miss(Addr lineAddr, Addr loadPC);
+void pref_ipcp_dl0_hit(Addr lineAddr, Addr loadPC);
+void pref_ipcp_dl0_pref_hit(Addr lineAddr, Addr loadPC);
+void pref_ipcp_mlc_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_mlc_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_mlc_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_l1_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_l1_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_l1_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipcp_umlc_cache_fill(uns8 proc_id, Addr fill_addr, Flag prefetch, Addr evicted_addr, uns32 metadata);
+
+/* --- FULL two-level IPCP: L1 IPCP at DL0 (dl0 hooks) + L2 IPCP at UMLC (umlc
+ *     hooks), coupled by the L1->L2 metadata channel. One pref_table entry. --- */
+
+/* --- SPP (vendor spp.l2c) at UL1/LLC; trained via ul1_cache_fill --- */
+void pref_spp_init(HWP* hwp);
+void pref_spp_per_core_done(uns proc_id);
+void pref_spp_dl0_miss(Addr lineAddr, Addr loadPC);
+void pref_spp_dl0_hit(Addr lineAddr, Addr loadPC);
+void pref_spp_dl0_pref_hit(Addr lineAddr, Addr loadPC);
+void pref_spp_mlc_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_mlc_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_mlc_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_l1_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_l1_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_l1_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_spp_ul1_cache_fill(uns8 proc_id, Addr fill_addr, Flag prefetch, Addr evicted_addr, uns32 metadata);
+
+/* --- IP-stride (vendor ip_stride.l2c, DPC2 baseline); trainable at any one level --- */
+void pref_ipstride_init(HWP* hwp);
+void pref_ipstride_per_core_done(uns proc_id);
+void pref_ipstride_dl0_miss(Addr lineAddr, Addr loadPC);
+void pref_ipstride_dl0_hit(Addr lineAddr, Addr loadPC);
+void pref_ipstride_dl0_pref_hit(Addr lineAddr, Addr loadPC);
+void pref_ipstride_mlc_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipstride_mlc_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipstride_mlc_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipstride_l1_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipstride_l1_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_ipstride_l1_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+
+/* --- next-line (vendor next_line.l2c, ChampSim streaming baseline) --- */
+void pref_nextline_init(HWP* hwp);
+void pref_nextline_per_core_done(uns proc_id);
+void pref_nextline_dl0_miss(Addr lineAddr, Addr loadPC);
+void pref_nextline_dl0_hit(Addr lineAddr, Addr loadPC);
+void pref_nextline_dl0_pref_hit(Addr lineAddr, Addr loadPC);
+void pref_nextline_mlc_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_nextline_mlc_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_nextline_mlc_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_nextline_l1_miss(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_nextline_l1_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+void pref_nextline_l1_pref_hit(uns8 proc_id, Addr lineAddr, Addr loadPC, uns32 global_hist);
+
+#endif  // __PREF_CHAMPSIM_H__

--- a/src/prefetcher/champsim/pref_champsim.stat.def
+++ b/src/prefetcher/champsim/pref_champsim.stat.def
@@ -1,0 +1,10 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/* Shared counters for all ChampSim-shim prefetchers. When several shim
+ * imports run together their events aggregate here; add per-import stats
+ * only when a breakdown is actually needed. */
+DEF_STAT(PREF_SHIM_OPERATE,    COUNT, NO_RATIO)
+DEF_STAT(PREF_SHIM_ISSUED,     COUNT, NO_RATIO)
+DEF_STAT(PREF_SHIM_QFULL,      COUNT, NO_RATIO)
+DEF_STAT(PREF_SHIM_USEFUL,     COUNT, NO_RATIO)
+DEF_STAT(PREF_SHIM_FILL,       COUNT, NO_RATIO)
+DEF_STAT(PREF_SHIM_CACHE_FILL, COUNT, NO_RATIO)

--- a/src/prefetcher/champsim/pref_ipstride.param.def
+++ b/src/prefetcher/champsim/pref_ipstride.param.def
@@ -1,0 +1,10 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/* -*- Mode: c -*- */
+/* Params for the ChampSim-shim IP-stride prefetcher (vendor: ip_stride.l2c,
+ * the DPC2 baseline). Enable/level via the framework instance lists: put
+ * TYPE_IPSTRIDE in exactly one of --pref_{dcache,mlc,l1}_prefetchers with its
+ * DEST_* destination token. */
+
+/* Route each prefetch by the vendor's adaptive FILL_L2/FILL_LLC choice
+ * (MSHR-occupancy based) instead of the instance's fixed DEST_* level. */
+DEF_PARAM(pref_ipstride_route_by_fill, PREF_IPSTRIDE_ROUTE_BY_FILL, Flag, Flag, FALSE, )

--- a/src/prefetcher/champsim/pref_ipstride.param.h
+++ b/src/prefetcher/champsim/pref_ipstride.param.h
@@ -1,0 +1,8 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+#ifndef __PREF_IPSTRIDE_PARAM_H__
+#define __PREF_IPSTRIDE_PARAM_H__
+#include "globals/global_types.h"
+#define DEF_PARAM(name, variable, type, func, def, const) extern const type variable;
+#include "pref_ipstride.param.def"
+#undef DEF_PARAM
+#endif

--- a/src/prefetcher/champsim/pref_mlop.param.def
+++ b/src/prefetcher/champsim/pref_mlop.param.def
@@ -1,0 +1,14 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/* -*- Mode: c -*- */
+/* Params for the ChampSim-shim MLOP (vendor: mlop_dpc3.l1d).
+ * One instance; enable by listing TYPE_MLOP in exactly one of
+ * --pref_{dcache,mlc,l1}_prefetchers with its DEST_* token.
+ * MLOP is multi-fill-level (issues FILL_L1 and FILL_L2). When
+ * PREF_MLOP_ROUTE_BY_FILL is TRUE, each prefetch is routed by its own fill
+ * level (FILL_L1->dcache, FILL_L2->mlc) instead of collapsing to the instance
+ * DEST_* level. Native placement is dcache (it is an L1D prefetcher). */
+
+/* Default FALSE: route all of MLOP's prefetches to the single drive level
+ * (collapsed) -- best IPC in Scarab's hierarchy. TRUE: faithful multi-fill, route
+ * each prefetch by its own fill level (FILL_L1->L1D, FILL_L2->L2). */
+DEF_PARAM(pref_mlop_route_by_fill, PREF_MLOP_ROUTE_BY_FILL, Flag, Flag, FALSE, )

--- a/src/prefetcher/champsim/pref_mlop.param.h
+++ b/src/prefetcher/champsim/pref_mlop.param.h
@@ -1,0 +1,11 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+#ifndef __PREF_MLOP_PARAM_H__
+#define __PREF_MLOP_PARAM_H__
+
+#include "globals/global_types.h"
+
+#define DEF_PARAM(name, variable, type, func, def, const) extern const type variable;
+#include "pref_mlop.param.def"
+#undef DEF_PARAM
+
+#endif  // __PREF_MLOP_PARAM_H__

--- a/src/prefetcher/champsim/shim_import.h
+++ b/src/prefetcher/champsim/shim_import.h
@@ -1,0 +1,195 @@
+/* Copyright 2020 HPS/SAFARI Research Groups
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Generic ChampSim import template: expands one UNMODIFIED vendor prefetcher
+ * into a complete shim wrapper (registry-gated init, operate glue, and the
+ * nine per-level hook trampolines). A simple import is a ~6-line stub:
+ *
+ *   // wrappers/pref_nextline.cc  (complete file)
+ *   #define SHIM_NAME    nextline                                  // token: names pref_<name>_* and TYPE_<NAME>
+ *   #define SHIM_VENDOR  "prefetcher/champsim/csenv/next_line.l2c.inc"
+ *   #define SHIM_API_L2C 1                                         // or SHIM_API_L1D: vendor entry-point family
+ *   #include "prefetcher/champsim/shim_import.h"
+ *
+ * plus a pref_table.def row. Events count into the shared PREF_SHIM_* stats
+ * (pref_champsim.stat.def).
+ *
+ * Optional knobs, defined before the include:
+ *   SHIM_EXTRA_INIT          statements pasted into init (e.g. set _route_by_fill from a param)
+ *   SHIM_EXTRA_OP            statements pasted before each operate (e.g. MSHR backpressure wiring)
+ *   SHIM_GEN_UL1_CACHE_FILL  also generate pref_<name>_ul1_cache_fill -> vendor l2c_prefetcher_cache_fill
+ *
+ * Each import must be its OWN translation unit: the vendor file carries
+ * file-scope state and CACHE method definitions, so the template wraps it in
+ * a private namespace (cs_<name>) whose fake cache.h is included once per TU.
+ * Imports needing custom glue beyond these knobs (ipcp's accuracy feedback,
+ * mlop's fill-routing) keep hand-written wrappers instead. */
+
+#if !defined(SHIM_NAME) || !defined(SHIM_VENDOR)
+#error "define SHIM_NAME and SHIM_VENDOR before including shim_import.h"
+#endif
+#if !defined(SHIM_API_L1D) && !defined(SHIM_API_L2C)
+#error "define SHIM_API_L1D or SHIM_API_L2C (the vendor's entry-point family)"
+#endif
+
+#include <bits/stdc++.h>
+
+extern "C" {
+#include "globals/assert.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "core.param.h"
+#include "general.param.h"
+#include "memory/memory.param.h"
+#include "prefetcher/pref.param.h"
+
+#include "memory/memory.h"
+#include "prefetcher/pref_common.h"
+
+#include "statistics.h"
+}
+
+#include "prefetcher/champsim/champsim_shim.h"
+#include "prefetcher/champsim/csenv/champsim.h"
+#include "prefetcher/champsim/csenv/memory_class.h"
+#include "prefetcher/champsim/csenv/ooo_cpu.h"
+
+#define SHIM_CAT2(a, b) a##b
+#define SHIM_CAT(a, b) SHIM_CAT2(a, b)
+#define SHIM_FN(suffix) SHIM_CAT(SHIM_CAT(pref_, SHIM_NAME), suffix)
+#define SHIM_STR2(x) #x
+#define SHIM_STR(x) SHIM_STR2(x)
+
+namespace SHIM_CAT(cs_, SHIM_NAME) {
+#include SHIM_VENDOR
+}  // namespace SHIM_CAT(cs_,SHIM_NAME)
+
+static SHIM_CAT(cs_, SHIM_NAME)::CACHE g_shim;
+static bool g_shim_inited = false;
+
+static inline uint64_t shim_line_addr(Addr lineAddr) {
+  return (uint64_t)(lineAddr & ((1ULL << 58) - 1ULL));
+}
+
+static inline champsim::Level shim_dest(HWP_Type d) {
+  return d == PREF_TO_DCACHE ? champsim::Level::DCACHE
+         : d == PREF_TO_UMLC ? champsim::Level::UMLC
+                             : champsim::Level::UL1;
+}
+
+extern "C" void SHIM_FN(_init)(HWP* hwp) {
+  if (!pref_hwp_enabled(hwp))
+    return;
+  int n = (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UL1) ? 1 : 0);
+  ASSERTM(0, n == 1, "champsim %s: enable at exactly ONE training level (single component)\n", SHIM_STR(SHIM_NAME));
+  Pref_Train_Level lvl = pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? PREF_TRAIN_LEVEL_DCACHE
+                         : pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? PREF_TRAIN_LEVEL_UMLC
+                                                                                 : PREF_TRAIN_LEVEL_UL1;
+  hwp->hwp_info->enabled = TRUE;
+  champsim::init_globals();
+  g_shim = SHIM_CAT(cs_, SHIM_NAME)::CACHE();
+  g_shim.cpu = 0;
+  g_shim.NAME = "champsim_" SHIM_STR(SHIM_NAME);
+  g_shim._level = shim_dest(pref_hwp_instance_dest(hwp, lvl));
+  g_shim._hwp_id = hwp->hwp_info->id;
+  g_shim._stat_issued = PREF_SHIM_ISSUED;
+  g_shim._stat_qfull = PREF_SHIM_QFULL;
+#ifdef SHIM_EXTRA_INIT
+  SHIM_EXTRA_INIT
+#endif
+#ifdef SHIM_API_L1D
+  g_shim.l1d_prefetcher_initialize();
+#else
+  g_shim.l2c_prefetcher_initialize();
+#endif
+  g_shim_inited = true;
+}
+
+extern "C" void SHIM_FN(_per_core_done)(uns /*proc_id*/) {
+}
+
+static inline void shim_op(uns8 proc_id, Addr lineAddr, Addr loadPC, uint8_t cache_hit) {
+  if (!g_shim_inited || proc_id != 0)
+    return; /* single-core shim */
+  STAT_EVENT(proc_id, PREF_SHIM_OPERATE);
+  champsim::tick(proc_id);
+  g_shim.cpu = proc_id;
+#ifdef SHIM_EXTRA_OP
+  SHIM_EXTRA_OP
+#endif
+#ifdef SHIM_API_L1D
+  g_shim.l1d_prefetcher_operate(shim_line_addr(lineAddr), (uint64_t)loadPC, cache_hit, (uint8_t)LOAD,
+                                /*critical_ip_flag=*/1);
+#else
+  g_shim.l2c_prefetcher_operate(shim_line_addr(lineAddr), (uint64_t)loadPC, cache_hit, (uint8_t)LOAD,
+                                /*metadata_in=*/0, /*critical_ip_flag=*/1);
+#endif
+}
+
+/* DCACHE (DL0 / L1D) hooks: (lineAddr, loadPC); proc_id from bit 58. */
+extern "C" void SHIM_FN(_dl0_miss)(Addr a, Addr pc) {
+  shim_op((uns8)(a >> 58), a, pc, 0);
+}
+extern "C" void SHIM_FN(_dl0_hit)(Addr a, Addr pc) {
+  shim_op((uns8)(a >> 58), a, pc, 1);
+}
+extern "C" void SHIM_FN(_dl0_pref_hit)(Addr a, Addr pc) {
+  shim_op((uns8)(a >> 58), a, pc, 1);
+}
+
+/* MLC (UMLC / L2) hooks. */
+extern "C" void SHIM_FN(_mlc_miss)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 0);
+}
+extern "C" void SHIM_FN(_mlc_hit)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 1);
+}
+extern "C" void SHIM_FN(_mlc_pref_hit)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 1);
+}
+
+/* L1 (UL1 / LLC) hooks. */
+extern "C" void SHIM_FN(_l1_miss)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 0);
+}
+extern "C" void SHIM_FN(_l1_hit)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 1);
+}
+extern "C" void SHIM_FN(_l1_pref_hit)(uns8 p, Addr a, Addr pc, uns32) {
+  shim_op(p, a, pc, 1);
+}
+
+#ifdef SHIM_GEN_UL1_CACHE_FILL
+/* UL1 (LLC) fill/eviction training hook -> vendor l2c_prefetcher_cache_fill. */
+extern "C" void SHIM_FN(_ul1_cache_fill)(uns8 proc_id, Addr fill_addr, Flag prefetch, Addr evicted_addr,
+                                         uns32 metadata) {
+  if (!g_shim_inited || proc_id != 0)
+    return;
+  STAT_EVENT(proc_id, PREF_SHIM_CACHE_FILL);
+  g_shim.cpu = proc_id;
+  g_shim.l2c_prefetcher_cache_fill(shim_line_addr(fill_addr), /*set=*/0, /*match=*/0, (uint8_t)(prefetch ? 1 : 0),
+                                   evicted_addr ? shim_line_addr(evicted_addr) : 0, metadata);
+}
+#endif

--- a/src/prefetcher/champsim/wrappers/pref_ipcp.cc
+++ b/src/prefetcher/champsim/wrappers/pref_ipcp.cc
@@ -1,0 +1,148 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/***************************************************************************************
+ * File         : prefetcher/champsim/wrappers/pref_ipcp.cc
+ * Description  : ChampSim-shim wrapper for the self-contained IPCP (vendor:
+ *                ipcp_isca2020.l1d — it computes its own strides/streams, so it works
+ *                standalone, unlike the L2 variant which needs an L1 metadata feed).
+ *
+ *                ONE instance, trained at exactly one Scarab cache level at a time by
+ *                listing TYPE_IPCP in one of --pref_{dcache,mlc,l1}_prefetchers with
+ *                its DEST_* token (dcache=L1D/DL0, mlc=L2/UMLC, l1=LLC/UL1). The
+ *                single pref_table entry carries hooks for all three levels; the
+ *                dispatchers fire only the listed training level's hooks, and
+ *                prefetch_line routing follows the instance's DEST_* destination. No
+ *                data-structure duplication (vendor tables live once in cs_ipcp).
+ ***************************************************************************************/
+
+#include <bits/stdc++.h>
+
+extern "C" {
+#include "globals/assert.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "core.param.h"
+#include "general.param.h"
+#include "memory/memory.param.h"
+#include "prefetcher/pref.param.h"
+
+#include "prefetcher/pref_common.h"
+
+#include "statistics.h"
+}
+
+#include "prefetcher/champsim/champsim_shim.h"
+#include "prefetcher/champsim/csenv/champsim.h"
+#include "prefetcher/champsim/csenv/memory_class.h"
+#include "prefetcher/champsim/csenv/ooo_cpu.h"
+
+/* === unmodified vendor source, isolated in a private namespace === */
+namespace cs_ipcp {
+#include "prefetcher/champsim/csenv/ipcp_isca2020.l1d.inc"
+}  // namespace cs_ipcp
+
+static cs_ipcp::CACHE g_ipcp;
+static bool g_ipcp_inited = false;
+
+static inline uint64_t cs_ipcp_addr(Addr lineAddr) {
+  return (uint64_t)(lineAddr & ((1ULL << 58) - 1ULL));
+}
+
+static inline champsim::Level cs_dest(HWP_Type d) {
+  return d == PREF_TO_DCACHE ? champsim::Level::DCACHE
+         : d == PREF_TO_UMLC ? champsim::Level::UMLC
+                             : champsim::Level::UL1;
+}
+
+extern "C" void pref_ipcp_init(HWP* hwp) {
+  if (!pref_hwp_enabled(hwp))
+    return;
+  int n = (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UL1) ? 1 : 0);
+  ASSERTM(0, n == 1, "champsim IPCP: list TYPE_IPCP at exactly ONE training level (single component)\n");
+  Pref_Train_Level lvl = pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? PREF_TRAIN_LEVEL_DCACHE
+                         : pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? PREF_TRAIN_LEVEL_UMLC
+                                                                                 : PREF_TRAIN_LEVEL_UL1;
+  hwp->hwp_info->enabled = TRUE;
+  champsim::init_globals();
+  g_ipcp = cs_ipcp::CACHE();
+  g_ipcp.cpu = 0;
+  g_ipcp.NAME = "champsim_ipcp";
+  g_ipcp._level = cs_dest(pref_hwp_instance_dest(hwp, lvl));
+  g_ipcp._hwp_id = hwp->hwp_info->id;
+  g_ipcp._stat_issued = PREF_SHIM_ISSUED;
+  g_ipcp._stat_qfull = PREF_SHIM_QFULL;
+  g_ipcp._stat_useful = PREF_SHIM_USEFUL;
+  g_ipcp._stat_fill = PREF_SHIM_FILL;
+  g_ipcp.l1d_prefetcher_initialize();
+  g_ipcp_inited = true;
+}
+
+extern "C" void pref_ipcp_per_core_done(uns /*proc_id*/) {
+}
+
+static inline void ipcp_op(uns8 proc_id, Addr lineAddr, Addr loadPC, uint8_t cache_hit) {
+  if (!g_ipcp_inited || proc_id != 0)
+    return; /* single-core shim */
+  STAT_EVENT(proc_id, PREF_SHIM_OPERATE);
+  champsim::tick(proc_id);
+  g_ipcp.cpu = proc_id;
+  g_ipcp.l1d_prefetcher_operate(cs_ipcp_addr(lineAddr), (uint64_t)loadPC, cache_hit, (uint8_t)LOAD,
+                                /*critical_ip_flag=*/1);
+}
+
+/* Useful-prefetch feedback: a demand hit on a line IPCP prefetched. The access's
+ * own operate already ran via the regular *_hit hook, so here we ONLY credit the
+ * prefetch (pref_useful[class]++), which drives the vendor's accuracy/degree throttle.
+ * Fires once per prefetched line (Scarab guards on !seen_prefetch). */
+static inline void ipcp_note_useful(uns8 proc_id, Addr lineAddr) {
+  if (!g_ipcp_inited || proc_id != 0)
+    return;
+  g_ipcp.cpu = proc_id;
+  g_ipcp.note_pref_hit(cs_ipcp_addr(lineAddr));
+}
+
+/* DCACHE (DL0 / L1D) hooks: signature (lineAddr, loadPC); proc_id from bit 58. */
+extern "C" void pref_ipcp_dl0_miss(Addr a, Addr pc) {
+  ipcp_op((uns8)(a >> 58), a, pc, 0);
+}
+extern "C" void pref_ipcp_dl0_hit(Addr a, Addr pc) {
+  ipcp_op((uns8)(a >> 58), a, pc, 1);
+}
+extern "C" void pref_ipcp_dl0_pref_hit(Addr a, Addr /*pc*/) {
+  ipcp_note_useful((uns8)(a >> 58), a);
+}
+
+/* MLC (UMLC / L2) hooks. */
+extern "C" void pref_ipcp_mlc_miss(uns8 p, Addr a, Addr pc, uns32) {
+  ipcp_op(p, a, pc, 0);
+}
+extern "C" void pref_ipcp_mlc_hit(uns8 p, Addr a, Addr pc, uns32) {
+  ipcp_op(p, a, pc, 1);
+}
+extern "C" void pref_ipcp_mlc_pref_hit(uns8 p, Addr a, Addr /*pc*/, uns32) {
+  ipcp_note_useful(p, a);
+}
+
+/* L1 (UL1 / LLC) hooks. */
+extern "C" void pref_ipcp_l1_miss(uns8 p, Addr a, Addr pc, uns32) {
+  ipcp_op(p, a, pc, 0);
+}
+extern "C" void pref_ipcp_l1_hit(uns8 p, Addr a, Addr pc, uns32) {
+  ipcp_op(p, a, pc, 1);
+}
+extern "C" void pref_ipcp_l1_pref_hit(uns8 p, Addr a, Addr /*pc*/, uns32) {
+  ipcp_note_useful(p, a);
+}
+
+/* MLC fill feedback: a prefetch IPCP issued filled the L2. Count it under its class
+ * (pref_filled[class]++) so acc = useful/filled reflects true accuracy. Counting at
+ * fill (not issue) avoids over-counting redundant/dropped issues. */
+extern "C" void pref_ipcp_umlc_cache_fill(uns8 p, Addr fill_addr, Flag prefetch, Addr /*evicted*/, uns32 /*meta*/) {
+  if (g_ipcp_inited && g_ipcp._level == champsim::Level::UMLC && prefetch && p == 0) {
+    g_ipcp.cpu = p;
+    g_ipcp.note_pref_fill(cs_ipcp_addr(fill_addr));
+  }
+}

--- a/src/prefetcher/champsim/wrappers/pref_ipstride.cc
+++ b/src/prefetcher/champsim/wrappers/pref_ipstride.cc
@@ -1,0 +1,19 @@
+/* Copyright 2020 HPS/SAFARI Research Groups (MIT license, see shim_import.h) */
+
+/* ChampSim's classic IP-stride prefetcher (DPC2 baseline, vendor:
+ * ip_stride.l2c, byte-for-byte). Enable by listing TYPE_IPSTRIDE in one of
+ * --pref_{dcache,mlc,l1}_prefetchers with its DEST_* token. The vendor tags
+ * prefetches FILL_L2/FILL_LLC adaptively by MSHR occupancy; the extra-op glue
+ * feeds it real occupancy, and --pref_ipstride_route_by_fill 1 routes each
+ * prefetch by that choice instead of the instance's fixed DEST_* level. */
+
+#include "prefetcher/champsim/pref_ipstride.param.h"
+
+#define SHIM_NAME ipstride
+#define SHIM_VENDOR "prefetcher/champsim/csenv/ip_stride.l2c.inc"
+#define SHIM_API_L2C 1
+#define SHIM_EXTRA_INIT g_shim._route_by_fill = PREF_IPSTRIDE_ROUTE_BY_FILL;
+#define SHIM_EXTRA_OP                        \
+  g_shim.MSHR.SIZE = MEM_REQ_BUFFER_ENTRIES; \
+  g_shim.MSHR.occupancy = mem_get_req_count(proc_id);
+#include "prefetcher/champsim/shim_import.h"

--- a/src/prefetcher/champsim/wrappers/pref_mlop.cc
+++ b/src/prefetcher/champsim/wrappers/pref_mlop.cc
@@ -1,0 +1,141 @@
+/* Copyright 2020 HPS/SAFARI Research Groups */
+/***************************************************************************************
+ * File         : prefetcher/champsim/wrappers/pref_mlop.cc
+ * Description  : ChampSim-shim wrapper for MLOP (DPC3'19). ONE instance; enable by
+ *                listing TYPE_MLOP in exactly one of --pref_{dcache,mlc,l1}_prefetchers
+ *                with its DEST_* token (the list selects the training level). MLOP is
+ *                multi-fill-level (issues FILL_L1 and FILL_L2): with
+ *                --pref_mlop_route_by_fill 1 each prefetch is routed by its own fill
+ *                level (FILL_L1->L1D/dcache, FILL_L2->L2/mlc); by default (FALSE) all
+ *                prefetches collapse onto the instance DEST_* level, which measures
+ *                best in Scarab. Native placement is dcache (it is an L1D prefetcher).
+ ***************************************************************************************/
+
+#include <bits/stdc++.h>
+
+#include "prefetcher/champsim/pref_mlop.param.h"
+
+extern "C" {
+#include "globals/assert.h"
+#include "globals/global_types.h"
+#include "globals/global_vars.h"
+#include "globals/utils.h"
+
+#include "core.param.h"
+#include "general.param.h"
+#include "memory/memory.param.h"
+#include "prefetcher/pref.param.h"
+
+#include "memory/memory.h"  // mem, mem_get_req_count, uncores[].num_outstanding_l1_misses
+#include "prefetcher/pref_common.h"
+
+#include "statistics.h"
+}
+
+#include "prefetcher/champsim/champsim_shim.h"
+#include "prefetcher/champsim/csenv/champsim.h"
+#include "prefetcher/champsim/csenv/memory_class.h"
+
+/* === unmodified vendor source, isolated in a private namespace === */
+namespace cs_mlop {
+#include "prefetcher/champsim/csenv/mlop_dpc3.l1d.inc"
+}  // namespace cs_mlop
+
+static cs_mlop::CACHE g_mlop;
+static bool g_mlop_inited = false;
+
+static inline uint64_t cs_mlop_addr(Addr lineAddr) {
+  return (uint64_t)(lineAddr & ((1ULL << 58) - 1ULL));
+}
+
+static inline champsim::Level cs_dest(HWP_Type d) {
+  return d == PREF_TO_DCACHE ? champsim::Level::DCACHE
+         : d == PREF_TO_UMLC ? champsim::Level::UMLC
+                             : champsim::Level::UL1;
+}
+
+extern "C" void pref_mlop_init(HWP* hwp) {
+  if (!pref_hwp_enabled(hwp))
+    return;
+  int n = (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? 1 : 0) +
+          (pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UL1) ? 1 : 0);
+  ASSERTM(0, n == 1, "champsim MLOP: list TYPE_MLOP at exactly ONE training level (single component)\n");
+  Pref_Train_Level lvl = pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_DCACHE) ? PREF_TRAIN_LEVEL_DCACHE
+                         : pref_hwp_instance_enabled(hwp, PREF_TRAIN_LEVEL_UMLC) ? PREF_TRAIN_LEVEL_UMLC
+                                                                                 : PREF_TRAIN_LEVEL_UL1;
+  hwp->hwp_info->enabled = TRUE;
+  champsim::init_globals();
+  g_mlop = cs_mlop::CACHE();
+  g_mlop.cpu = 0;
+  g_mlop.NAME = "champsim_mlop";
+  g_mlop._level = cs_dest(pref_hwp_instance_dest(hwp, lvl));
+  /* Default: collapse all fills onto the drive level (best IPC in Scarab's tiny
+   * L1D). Set --pref_mlop_route_by_fill 1 for faithful multi-fill (FILL_L1->L1D,
+   * FILL_L2->L2; needs --pref_dl0_fill_dcache for real L1D fills). */
+  g_mlop._route_by_fill = PREF_MLOP_ROUTE_BY_FILL;
+  g_mlop._hwp_id = hwp->hwp_info->id;
+  g_mlop._stat_issued = PREF_SHIM_ISSUED;
+  g_mlop._stat_qfull = PREF_SHIM_QFULL;
+  /* Cache geometry MLOP uses only to size its access-map table. */
+  g_mlop.NUM_SET = 1024;
+  g_mlop.NUM_WAY = 16;
+  g_mlop.l1d_prefetcher_initialize();
+  g_mlop_inited = true;
+}
+
+extern "C" void pref_mlop_per_core_done(uns /*proc_id*/) {
+}
+
+static inline void mlop_op(uns8 proc_id, Addr lineAddr, Addr loadPC, uint8_t cache_hit, uint8_t pref_hit) {
+  if (!g_mlop_inited || proc_id != 0)
+    return; /* single-core shim */
+  STAT_EVENT(proc_id, PREF_SHIM_OPERATE);
+  champsim::tick(proc_id);
+  g_mlop.cpu = proc_id;
+  g_mlop.begin_operate(); /* reset per-operate dedup set */
+  /* Real backpressure (READ-ONLY Scarab state) so MLOP's built-in PQ/MSHR throttle
+   * self-limits like ChampSim (MEM_REQ_BUFFER_ENTRIES==32 matches ChampSim MSHR). */
+  g_mlop.MSHR.SIZE = MEM_REQ_BUFFER_ENTRIES;
+  g_mlop.MSHR.occupancy = mem_get_req_count(proc_id);
+  g_mlop.PQ.SIZE = PREF_UMLC_REQ_QUEUE_SIZE;
+  g_mlop.PQ.occupancy = mem->uncores[proc_id].num_outstanding_l1_misses;
+  /* MLOP detects a prefetch-hit via block[set][way].prefetch when cache_hit==1. */
+  g_mlop._blk.prefetch = pref_hit;
+  g_mlop._blk.valid = 1;
+  g_mlop.l1d_prefetcher_operate(cs_mlop_addr(lineAddr), (uint64_t)loadPC, cache_hit, (uint8_t)LOAD,
+                                /*critical_ip_flag=*/1);
+}
+
+/* DCACHE (DL0 / L1D) hooks: (lineAddr, loadPC); proc_id from bit 58. Native level. */
+extern "C" void pref_mlop_dl0_miss(Addr a, Addr pc) {
+  mlop_op((uns8)(a >> 58), a, pc, 0, 0);
+}
+extern "C" void pref_mlop_dl0_hit(Addr a, Addr pc) {
+  mlop_op((uns8)(a >> 58), a, pc, 1, 0);
+}
+extern "C" void pref_mlop_dl0_pref_hit(Addr a, Addr pc) {
+  mlop_op((uns8)(a >> 58), a, pc, 1, 1);
+}
+
+/* MLC (UMLC / L2) hooks. */
+extern "C" void pref_mlop_mlc_miss(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 0, 0);
+}
+extern "C" void pref_mlop_mlc_hit(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 1, 0);
+}
+extern "C" void pref_mlop_mlc_pref_hit(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 1, 1);
+}
+
+/* L1 (UL1 / LLC) hooks. */
+extern "C" void pref_mlop_l1_miss(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 0, 0);
+}
+extern "C" void pref_mlop_l1_hit(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 1, 0);
+}
+extern "C" void pref_mlop_l1_pref_hit(uns8 p, Addr a, Addr pc, uns32) {
+  mlop_op(p, a, pc, 1, 1);
+}

--- a/src/prefetcher/champsim/wrappers/pref_nextline.cc
+++ b/src/prefetcher/champsim/wrappers/pref_nextline.cc
@@ -1,0 +1,10 @@
+/* Copyright 2020 HPS/SAFARI Research Groups (MIT license, see shim_import.h) */
+
+/* ChampSim's next-line prefetcher (the official sequential/streaming baseline,
+ * vendor: next_line.l2c, byte-for-byte). Enable by listing TYPE_NEXTLINE in
+ * one of --pref_{dcache,mlc,l1}_prefetchers with its DEST_* token. */
+
+#define SHIM_NAME nextline
+#define SHIM_VENDOR "prefetcher/champsim/csenv/next_line.l2c.inc"
+#define SHIM_API_L2C 1
+#include "prefetcher/champsim/shim_import.h"

--- a/src/prefetcher/champsim/wrappers/pref_spp.cc
+++ b/src/prefetcher/champsim/wrappers/pref_spp.cc
@@ -1,0 +1,12 @@
+/* Copyright 2020 HPS/SAFARI Research Groups (MIT license, see shim_import.h) */
+
+/* SPP (Signature Path Prefetcher, vendor: spp.l2c + spp.h, byte-for-byte).
+ * Enable by listing TYPE_SPP in one of --pref_{dcache,mlc,l1}_prefetchers with
+ * its DEST_* token; also generates the ul1_cache_fill hook so SPP's
+ * eviction-based training works when trained at the LLC. */
+
+#define SHIM_NAME spp
+#define SHIM_VENDOR "prefetcher/champsim/csenv/spp.l2c.inc"
+#define SHIM_API_L2C 1
+#define SHIM_GEN_UL1_CACHE_FILL 1
+#include "prefetcher/champsim/shim_import.h"

--- a/src/prefetcher/pref_common.c
+++ b/src/prefetcher/pref_common.c
@@ -53,6 +53,7 @@
 #include "prefetcher//pref_stream.h"
 #include "prefetcher//pref_stride.h"
 #include "prefetcher//pref_stridepc.h"
+#include "prefetcher/champsim/pref_champsim.h"
 #include "prefetcher/l2l1pref.h"
 #include "prefetcher/pref_2dc.h"
 #include "prefetcher/pref_ghb.h"

--- a/src/prefetcher/pref_table.def
+++ b/src/prefetcher/pref_table.def
@@ -84,6 +84,53 @@ HWP pref_table [] = {
           pref_markov_umlc_miss,        		NULL,  	pref_markov_umlc_prefhit,   		
 	    pref_markov_ul1_miss, 		NULL,    pref_markov_ul1_prefhit  , NULL, NULL   }, 
 
+    /* === ChampSim shim prefetchers (src/prefetcher/champsim) === */
+
+    /* MLOP: hooks at all three levels; the training level comes from which
+       pref_{dcache,mlc,l1}_prefetchers list TYPE_MLOP appears in. */
+    { "mlop",     NULL,   		pref_mlop_init,     	NULL,
+                  pref_mlop_per_core_done,
+		  pref_mlop_dl0_miss,   pref_mlop_dl0_hit,      pref_mlop_dl0_pref_hit,
+		  pref_mlop_mlc_miss,   pref_mlop_mlc_hit,      pref_mlop_mlc_pref_hit,
+		  pref_mlop_l1_miss,    pref_mlop_l1_hit,       pref_mlop_l1_pref_hit,
+		  NULL, NULL   },
+
+    /* Self-contained IPCP: hooks at all three levels; trained at the level whose
+       list names TYPE_IPCP. umlc_cache_fill feeds its accuracy throttle. */
+    { "ipcp",     NULL,   		pref_ipcp_init,     	NULL,
+                  pref_ipcp_per_core_done,
+		  pref_ipcp_dl0_miss,   pref_ipcp_dl0_hit,      pref_ipcp_dl0_pref_hit,
+		  pref_ipcp_mlc_miss,   pref_ipcp_mlc_hit,      pref_ipcp_mlc_pref_hit,
+		  pref_ipcp_l1_miss,    pref_ipcp_l1_hit,       pref_ipcp_l1_pref_hit,
+		  NULL,                 pref_ipcp_umlc_cache_fill   },
+
+    /* ChampSim next-line (sequential/streaming baseline): hooks at all three
+       levels; trained at the level whose list names TYPE_NEXTLINE. */
+    { "nextline",  NULL,   		pref_nextline_init,   	NULL,
+                  pref_nextline_per_core_done,
+		  pref_nextline_dl0_miss, pref_nextline_dl0_hit, pref_nextline_dl0_pref_hit,
+		  pref_nextline_mlc_miss, pref_nextline_mlc_hit, pref_nextline_mlc_pref_hit,
+		  pref_nextline_l1_miss,  pref_nextline_l1_hit,  pref_nextline_l1_pref_hit,
+		  NULL, NULL   },
+
+    /* ChampSim IP-stride (DPC2 baseline): hooks at all three levels; trained at
+       the level whose list names TYPE_IPSTRIDE. */
+    { "ipstride",  NULL,   		pref_ipstride_init,   	NULL,
+                  pref_ipstride_per_core_done,
+		  pref_ipstride_dl0_miss, pref_ipstride_dl0_hit, pref_ipstride_dl0_pref_hit,
+		  pref_ipstride_mlc_miss, pref_ipstride_mlc_hit, pref_ipstride_mlc_pref_hit,
+		  pref_ipstride_l1_miss,  pref_ipstride_l1_hit,  pref_ipstride_l1_pref_hit,
+		  NULL, NULL   },
+
+    /* SPP: hooks at all three levels (trained at the level whose list names
+       TYPE_SPP) + the ul1_cache_fill eviction-training hook. */
+    { "spp",      NULL,   		pref_spp_init,      	NULL,
+                  pref_spp_per_core_done,
+		  pref_spp_dl0_miss,    pref_spp_dl0_hit,       pref_spp_dl0_pref_hit,
+		  pref_spp_mlc_miss,    pref_spp_mlc_hit,       pref_spp_mlc_pref_hit,
+		  pref_spp_l1_miss,     pref_spp_l1_hit,        pref_spp_l1_pref_hit,
+		  pref_spp_ul1_cache_fill, NULL },
+
     { NULL,  NULL,   		NULL,    		NULL,
                   NULL,
 		  NULL,        		NULL,      		NULL,      

--- a/src/stat_files.def
+++ b/src/stat_files.def
@@ -37,4 +37,5 @@
 #include "prefetcher/l2l1pref.stat.def" 
 #include "power/power.stat.def"
 #include "prefetcher/pref.stat.def"
+#include "prefetcher/champsim/pref_champsim.stat.def"
 


### PR DESCRIPTION
## What this is

A self-contained adapter that runs unmodified ChampSim (DPC-style) prefetchers inside Scarab's prefetch framework. Vendor prefetcher source is imported byte-for-byte; all Scarab awareness lives in the shim. Six prefetchers are included: IPCP, MLOP, SPP, a two-level cooperating IPCP, and the ChampSim baselines IP-stride and next-line.

## Structure & how an import works

    src/prefetcher/champsim/
    |-- csenv/            fake ChampSim environment + UNMODIFIED vendor .inc files
    |-- champsim_shim.*   shim core (address conversion, issue path, clock/stat bridges)
    |-- shim_import.h     import template: expands a vendor file into a full wrapper
    |-- wrappers/         one small .cc per import (state isolation requires one TU each)
    `-- pref_*.{param,stat}.def   per-prefetcher knobs/counters

Inbound (training): Scarab's existing per-level dispatchers (pref_dl0/umlc/ul1_{miss,hit,pref_hit}) call the import's pref_table.def hooks, gated by the instance lists from #543 -- the list a type appears in (--pref_mlc_prefetchers TYPE_IPCP,DEST_MLC) decides which cache level's traffic trains it. The wrapper strips Scarab's proc-id tag off the address, refreshes the fake warmup_complete[]/current_core_cycle[], and calls the vendor's own *_prefetcher_operate().

Outbound (emission): the vendor calls what it believes is ChampSim's CACHE::prefetch_line(); the fake csenv/cache.h forwards to shim_issue(), which re-stamps the proc-id (convert_to_cmp_addr) and enqueues through the framework's single routing primitive pref_addto_dest_req_queue() at the instance's DEST_* level. From that point the prefetch is indistinguishable from a native one (per-level queues, drain, MRT_DPRF, inclusive fills).

Feedback: demand pref-hits and L2 fills are bridged to note_pref_hit/note_pref_fill, so vendor-internal control loops (IPCP's per-class accuracy throttle) run on real Scarab events; MSHR occupancy is wired read-only so vendor backpressure heuristics (MLOP, IP-stride's adaptive fill level) see genuine state.

Adding a prefetcher = copy the vendor file verbatim + a stub:

    // wrappers/pref_nextline.cc -- complete file
    #define SHIM_NAME    nextline
    #define SHIM_UNAME   NEXTLINE
    #define SHIM_VENDOR  "prefetcher/champsim/csenv/next_line.l2c.inc"
    #define SHIM_API_L2C 1
    #include "prefetcher/champsim/shim_import.h"

plus a table row and a 3-line stat.def (~30 lines marginal cost). Optional knobs: SHIM_EXTRA_INIT/SHIM_EXTRA_OP (custom glue), SHIM_GEN_UL1_CACHE_FILL (eviction-trained vendors). One instance per shim type at one training level for now (asserted; the vendors keep state in file-scope globals, so multi-level instancing needs per-level stamping -- documented follow-up).

## Files changed (46, +5,199)

| category | LOC | role |
|---|---:|---|
| Vendor code | 3,414 | **unmodified** ChampSim/DPC source |
| Env fakes | 280 | glue |
| Shim core | 161 | glue |
| Import template | 199 | glue |
| Wrappers | 529 | glue |
| Decls + knobs | 229 | glue |
| Integration | 81 | table rows, build, stat/param regs |

**Vendor (never edited):** `csenv/{ipcp_isca2020.l1d, ipcp_isca2020.l2c, mlop_dpc3.l1d, spp.l2c, ip_stride.l2c, next_line.l2c}.inc`, `csenv/spp.h` — byte-for-byte copies.

**Env fakes:** `csenv/cache.h` (fake `CACHE`: `prefetch_line`→shim, MSHR/PQ occupancy, block state, pref-hit/fill feedback, metadata channel), `csenv/champsim.h` / `memory_class.h` / `ooo_cpu.h` (globals, `FILL_*`, types).

**Shim core:** `champsim_shim.{h,cc}` — proc-id tag strip/re-stamp, `shim_issue` → `pref_addto_dest_req_queue`, clock tick, stat bridge.

**Import template:** `shim_import.h` — expands registry-gated init, operate glue, and all nine hook trampolines from four `#define`s.

**Wrappers:** three template stubs (`nextline` 11 LOC, `spp` 13, `ipstride` 20) plus three hand-written where the glue is prefetcher-specific behavior: `ipcp` (per-class accuracy feedback, 149), `mlop` (fill routing + backpressure, 139), `ipcp_full_l1/l2` (L1→L2 metadata channel, 197).

**Decls + knobs:** `pref_champsim.h` (C-visible hook declarations), per-prefetcher `.param.def/.param.h/.stat.def`.

**Integration (only touches outside `champsim/`, all additive):** `pref_table.def` +6 rows, `stat_files.def`/`param_files.def` +11 lines, `CMakeLists.txt` +12, and a single include in `pref_common.c`.
