### PR TITLE
[BUG] Reduce Memory consumption #466 Fix! Results at Bottom!

### DIFF
--- a/src/prefetcher/fdip.cc
+++ b/src/prefetcher/fdip.cc
@@ -19,6 +19,7 @@ extern "C" {
 }
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -133,12 +134,25 @@ class FDIP_Stat {
   unordered_map<Addr, vector<uns8>> useful_sequence;
   // <CL address, sequence of hit/miss>
   unordered_map<Addr, vector<uns8>> icache_sequence;
-  // <CL address, all sequence> char - P: prefetch, p: not prefetch, m: icache miss, h: icache hit, U: useful, u:
-  // unuseful (Counter - cycle count)
-  unordered_map<Addr, vector<pair<char, Counter>>> sequence_bw;
-  // <CL address, all sequence> char - P: prefetch, p: not prefetch, m: icache miss, h: icache hit, U: useful, u:
-  // unuseful (Counter - cycle count)
+  // Before warmup, consumers only need to know whether each event type occurred;
+  // a bitmask avoids retaining duplicate events, ordering, and cycle timestamps.
+  enum SequenceBwEvent : uint8_t {
+    BW_p = 1u << 0,
+    BW_P = 1u << 1,
+    BW_m = 1u << 2,
+    BW_h = 1u << 3,
+    BW_u = 1u << 4,
+    BW_U = 1u << 5,
+    BW_e = 1u << 6,
+  };
+  unordered_map<Addr, uint8_t> sequence_bw;
+
+  // sequence_aw stores the complete per-cache-line event history required by
+  // print_cl_info(), including event order, duplicates, and cycle timestamps.
+  // Only populate it when FDIP_PRINT_CL_INFO is enabled; otherwise this history
+  // is never consumed and retaining it causes unnecessary memory growth.
   unordered_map<Addr, vector<pair<char, Counter>>> sequence_aw;
+
   // <CL address, total miss delay>
   map<Addr, Counter> per_line_delay_aw;
   Counter cur_line_delay;
@@ -621,21 +635,10 @@ void FDIP_Stat::inc_cnt_unuseful(Addr line_addr) {
     else
       it->second++;
 
-    auto it2 = sequence_aw.find(line_addr);
-    if (it2 == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO)
       sequence_aw[line_addr].push_back(make_pair('u', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('u', cycle_count));
-    }
   } else {
-    auto it2 = sequence_bw.find(line_addr);
-    if (it2 == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('u', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('u', cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_u;
   }
 }
 
@@ -661,21 +664,11 @@ void FDIP_Stat::inc_cnt_useful(Addr line_addr, Flag pref_miss) {
       it->second.second = pref_miss;
     }
 
-    auto it2 = sequence_aw.find(line_addr);
-    if (it2 == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO) {
       sequence_aw[line_addr].push_back(make_pair('U', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('U', cycle_count));
     }
   } else {
-    auto iter = sequence_bw.find(line_addr);
-    if (iter == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('U', cycle_count));
-    } else {
-      iter->second.push_back(make_pair('U', cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_U;
   }
 }
 
@@ -687,23 +680,12 @@ void FDIP_Stat::probe_prefetched_cls(Addr line_addr) {
 
 void FDIP_Stat::not_prefetch(Addr line_addr) {
   if (g_fdip->get_warmed_up()) {
-    auto it = sequence_aw.find(line_addr);
-    Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-    if (it == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO) {
+      const Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
       sequence_aw[line_addr].push_back(make_pair('p', onoff_cycle_count));
-    } else {
-      it->second.push_back(make_pair('p', onoff_cycle_count));
     }
   } else {
-    auto it = sequence_bw.find(line_addr);
-    Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-    if (it == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('p', onoff_cycle_count));
-    } else {
-      it->second.push_back(make_pair('p', onoff_cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_p;
   }
 }
 
@@ -722,23 +704,13 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
     else
       it->second++;
 
-    auto it2 = sequence_aw.find(line_addr);
-    if (it2 == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO) {
       sequence_aw[line_addr].push_back(make_pair('m', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('m', cycle_count));
     }
 
     cur_line_delay = cycle_count;
   } else {
-    auto it2 = sequence_bw.find(line_addr);
-    if (it2 == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('m', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('m', cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_m;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 2 : 0;
@@ -750,19 +722,12 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
       auto it2 = sequence_bw.find(line_addr);
       if (it2 != sequence_bw.end()) {
         STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_SEEN_DURING_WARMUP);
-        Counter no_pref = 0;
-        Counter unuseful = 0;
-        Counter useful = 0;
-        auto it3 = it2->second.begin();
-        while (it3 != it2->second.end()) {
-          if (it3->first == 'p')
-            no_pref++;
-          else if (it3->first == 'u')
-            useful++;
-          else if (it3->first == 'U')
-            unuseful++;
-          ++it3;
-        }
+        const uint8_t state = it2->second;
+        const bool no_pref = state & BW_p;
+        // Preserve the legacy sequence_bw interpretation: lowercase 'u' drives
+        // the useful predicate, while uppercase 'U' drives the unuseful predicate.
+        const bool useful = state & BW_u;
+        const bool unuseful = state & BW_U;
         if (no_pref && !unuseful && !useful)
           STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_NO_PREF_DURING_WARMUP);
         if (!no_pref && unuseful && !useful)
@@ -817,23 +782,12 @@ void FDIP_Stat::inc_prefetched_cls(Addr line_addr, Flag on_path, uns success) {
         it->second++;
     }
 
-    auto it2 = sequence_aw.find(line_addr);
-    Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-    if (it2 == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO) {
+      const Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
       sequence_aw[line_addr].push_back(make_pair('P', onoff_cycle_count));
-    } else {
-      it2->second.push_back(make_pair('P', onoff_cycle_count));
     }
   } else {
-    auto it2 = sequence_bw.find(line_addr);
-    Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-    if (it2 == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('P', onoff_cycle_count));
-    } else {
-      it2->second.push_back(make_pair('P', onoff_cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_P;
   }
 }
 
@@ -869,13 +823,8 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
     else
       it->second++;
 
-    auto it2 = sequence_aw.find(line_addr);
-    if (it2 == sequence_aw.end()) {
-      sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO)
       sequence_aw[line_addr].push_back(make_pair('h', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('h', cycle_count));
-    }
 
     if (cur_line_delay) {
       auto it3 = per_line_delay_aw.find(line_addr);
@@ -887,13 +836,7 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
     }
     cur_line_delay = 0;
   } else {
-    auto it2 = sequence_bw.find(line_addr);
-    if (it2 == sequence_bw.end()) {
-      sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      sequence_bw[line_addr].push_back(make_pair('h', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('h', cycle_count));
-    }
+    sequence_bw[line_addr] |= BW_h;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 3 : 1;
@@ -1540,21 +1483,10 @@ void FDIP::assert_break_reason(Addr line_addr) {
 
 void FDIP::add_evict_seq(Addr line_addr) {
   if (warmed_up) {
-    auto it2 = fdip_stat->sequence_aw.find(line_addr);
-    if (it2 == fdip_stat->sequence_aw.end()) {
-      fdip_stat->sequence_aw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
+    if (FDIP_PRINT_CL_INFO)
       fdip_stat->sequence_aw[line_addr].push_back(make_pair('e', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('e', cycle_count));
-    }
   } else {
-    auto it2 = fdip_stat->sequence_bw.find(line_addr);
-    if (it2 == fdip_stat->sequence_bw.end()) {
-      fdip_stat->sequence_bw.insert(make_pair(line_addr, vector<pair<char, Counter>>()));
-      fdip_stat->sequence_bw[line_addr].push_back(make_pair('e', cycle_count));
-    } else {
-      it2->second.push_back(make_pair('e', cycle_count));
-    }
+    fdip_stat->sequence_bw[line_addr] |= FDIP_Stat::BW_e;
   }
 }
 

--- a/src/prefetcher/fdip.cc
+++ b/src/prefetcher/fdip.cc
@@ -130,28 +130,31 @@ class FDIP_Stat {
   // <CL address, cyc_access_by_fdip, conf_on/off-path, cyc_evicted_from_l1_by_demand_load, cyc_evicted_from_l1_by_FDIP>
   // - prefetched and access time information for timeliness analysis
   unordered_map<Addr, pair<pair<Counter, Flag>, pair<Counter, Counter>>> prefetched_cls_info;
-  // <CL address, sequence of useful/unuseful>
-  unordered_map<Addr, vector<uns8>> useful_sequence;
-  // <CL address, sequence of hit/miss>
-  unordered_map<Addr, vector<uns8>> icache_sequence;
-  // Before warmup, consumers only need to know whether each event type occurred;
+  // Per-cache-line usefulness history emitted by print_cl_info(). The vectors
+  // are populated only when FDIP_PRINT_CL_INFO is enabled.
+  unordered_map<Addr, vector<uns8>> usefulness_history;
+  // Per-cache-line hit/miss history emitted by print_cl_info(). The vectors are
+  // populated only when FDIP_PRINT_CL_INFO is enabled, but map-entry existence
+  // is also used to identify a cache line's first recorded access.
+  unordered_map<Addr, vector<uns8>> icache_access_history;
+  // Consumers only need to know whether each cache-line event type occurred;
   // a bitmask avoids retaining duplicate events, ordering, and cycle timestamps.
-  enum WarmupEvent : uint8_t {
-    WARMUP_EVENT_p = 1u << 0,
-    WARMUP_EVENT_P = 1u << 1,
-    WARMUP_EVENT_m = 1u << 2,
-    WARMUP_EVENT_h = 1u << 3,
-    WARMUP_EVENT_u = 1u << 4,
-    WARMUP_EVENT_U = 1u << 5,
-    WARMUP_EVENT_e = 1u << 6,
+  enum CachelineEvent : uint8_t {
+    CACHELINE_EVENT_NOT_PREFETCHED = 1u << 0,
+    CACHELINE_EVENT_PREFETCHED = 1u << 1,
+    CACHELINE_EVENT_ICACHE_MISS = 1u << 2,
+    CACHELINE_EVENT_ICACHE_HIT = 1u << 3,
+    CACHELINE_EVENT_UNUSEFUL = 1u << 4,
+    CACHELINE_EVENT_USEFUL = 1u << 5,
+    CACHELINE_EVENT_EVICTED = 1u << 6,
   };
-  unordered_map<Addr, uint8_t> warmup_events;
+  unordered_map<Addr, uint8_t> cacheline_events;
 
-  // sequence_aw stores the complete per-cache-line event history required by
-  // print_cl_info(), including event order, duplicates, and cycle timestamps.
-  // Only populate it when FDIP_PRINT_CL_INFO is enabled; otherwise this history
+  // Complete per-cache-line event history emitted by print_cl_info(), including
+  // event order, duplicates, and cycle timestamps. Populate it only when
+  // FDIP_PRINT_CL_INFO is enabled; otherwise this history
   // is never consumed and retaining it causes unnecessary memory growth.
-  unordered_map<Addr, vector<pair<char, Counter>>> sequence_aw;
+  unordered_map<Addr, vector<pair<char, Counter>>> cacheline_event_history;
 
   // <CL address, total miss delay>
   map<Addr, Counter> per_line_delay_aw;
@@ -552,7 +555,7 @@ void FDIP_Stat::print_cl_info(Icache_Stage* ic_ref) {
 
   fp = fopen("per_line_useful_seq.csv", "w");
   fprintf(fp, "cl_addr,seq\n");
-  for (auto it = useful_sequence.begin(); it != useful_sequence.end(); ++it) {
+  for (auto it = usefulness_history.begin(); it != usefulness_history.end(); ++it) {
     fprintf(fp, "%llx", it->first);
     for (auto it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
       fprintf(fp, ",%u", *it2);
@@ -563,7 +566,7 @@ void FDIP_Stat::print_cl_info(Icache_Stage* ic_ref) {
 
   fp = fopen("per_line_icache_seq.csv", "w");
   fprintf(fp, "cl_addr,seq\n");
-  for (auto it = icache_sequence.begin(); it != icache_sequence.end(); ++it) {
+  for (auto it = icache_access_history.begin(); it != icache_access_history.end(); ++it) {
     fprintf(fp, "%llx", it->first);
     for (auto it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
       fprintf(fp, ",%u", *it2);
@@ -574,7 +577,7 @@ void FDIP_Stat::print_cl_info(Icache_Stage* ic_ref) {
 
   fp = fopen("per_line_seq_aw.csv", "w");
   fprintf(fp, "cl_addr,seq\n");
-  for (auto it = sequence_aw.begin(); it != sequence_aw.end(); ++it) {
+  for (auto it = cacheline_event_history.begin(); it != cacheline_event_history.end(); ++it) {
     fprintf(fp, "%llx", it->first);
     if (it->second.size() == 2) {
       auto it2 = it->second.begin();
@@ -609,13 +612,9 @@ void FDIP_Stat::inc_cnt_useful_signed(Addr line_addr) {
   else if (it->second + UDP_WEIGHT_USEFUL <= UDP_WEIGHT_POSITIVE_SATURATION)
     it->second += UDP_WEIGHT_USEFUL;
 
-  uns8 useful_value = g_fdip->get_warmed_up() ? 3 : 1;
-  auto it2 = useful_sequence.find(line_addr);
-  if (it2 == useful_sequence.end()) {
-    useful_sequence.insert(make_pair(line_addr, vector<uns8>()));
-    useful_sequence[line_addr].push_back(useful_value);
-  } else {
-    it2->second.push_back(useful_value);
+  if (FDIP_PRINT_CL_INFO) {
+    const uns8 useful_value = g_fdip->get_warmed_up() ? 3 : 1;
+    usefulness_history[line_addr].push_back(useful_value);
   }
 }
 
@@ -636,9 +635,9 @@ void FDIP_Stat::inc_cnt_unuseful(Addr line_addr) {
       it->second++;
 
     if (FDIP_PRINT_CL_INFO)
-      sequence_aw[line_addr].push_back(make_pair('u', cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('u', cycle_count));
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_u;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_UNUSEFUL;
   }
 }
 
@@ -665,10 +664,10 @@ void FDIP_Stat::inc_cnt_useful(Addr line_addr, Flag pref_miss) {
     }
 
     if (FDIP_PRINT_CL_INFO) {
-      sequence_aw[line_addr].push_back(make_pair('U', cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('U', cycle_count));
     }
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_U;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_USEFUL;
   }
 }
 
@@ -682,10 +681,10 @@ void FDIP_Stat::not_prefetch(Addr line_addr) {
   if (g_fdip->get_warmed_up()) {
     if (FDIP_PRINT_CL_INFO) {
       const Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-      sequence_aw[line_addr].push_back(make_pair('p', onoff_cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('p', onoff_cycle_count));
     }
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_p;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_NOT_PREFETCHED;
   }
 }
 
@@ -705,29 +704,31 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
       it->second++;
 
     if (FDIP_PRINT_CL_INFO) {
-      sequence_aw[line_addr].push_back(make_pair('m', cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('m', cycle_count));
     }
 
     cur_line_delay = cycle_count;
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_m;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_ICACHE_MISS;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 2 : 0;
-  auto it = icache_sequence.find(line_addr);
-  if (it == icache_sequence.end()) {
-    icache_sequence.insert(make_pair(line_addr, vector<uns8>()));
-    icache_sequence[line_addr].push_back(icache_val);
+  auto it = icache_access_history.find(line_addr);
+  if (it == icache_access_history.end()) {
+    icache_access_history.insert(make_pair(line_addr, vector<uns8>()));
+    if (FDIP_PRINT_CL_INFO)
+      icache_access_history[line_addr].push_back(icache_val);
     if (icache_val == 2) {
-      auto it2 = warmup_events.find(line_addr);
-      if (it2 != warmup_events.end()) {
+      auto it2 = cacheline_events.find(line_addr);
+      if (it2 != cacheline_events.end()) {
         STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_SEEN_DURING_WARMUP);
         const uint8_t state = it2->second;
-        const bool no_pref = state & WARMUP_EVENT_p;
-        // Preserve the legacy before-warmup event interpretation: lowercase 'u' drives
-        // the useful predicate, while uppercase 'U' drives the unuseful predicate.
-        const bool useful = state & WARMUP_EVENT_u;
-        const bool unuseful = state & WARMUP_EVENT_U;
+        const bool no_pref = state & CACHELINE_EVENT_NOT_PREFETCHED;
+        // Preserve the legacy interpretation: the events produced by
+        // inc_cnt_unuseful() and inc_cnt_useful() drive the opposite-named
+        // first-miss predicates. Changing it would alter existing FDIP statistics.
+        const bool useful = state & CACHELINE_EVENT_UNUSEFUL;
+        const bool unuseful = state & CACHELINE_EVENT_USEFUL;
         if (no_pref && !unuseful && !useful)
           STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_NO_PREF_DURING_WARMUP);
         if (!no_pref && unuseful && !useful)
@@ -737,7 +738,7 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
       } else
         STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_NOT_SEEN_DURING_WARMUP);
     }
-  } else {
+  } else if (FDIP_PRINT_CL_INFO) {
     it->second.push_back(icache_val);
   }
 }
@@ -784,10 +785,10 @@ void FDIP_Stat::inc_prefetched_cls(Addr line_addr, Flag on_path, uns success) {
 
     if (FDIP_PRINT_CL_INFO) {
       const Counter onoff_cycle_count = fdip_off_path(proc_id, bp_id) ? -cycle_count : cycle_count;
-      sequence_aw[line_addr].push_back(make_pair('P', onoff_cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('P', onoff_cycle_count));
     }
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_P;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_PREFETCHED;
   }
 }
 
@@ -798,13 +799,9 @@ void FDIP_Stat::dec_cnt_useful_signed(Addr line_addr) {
   else
     it->second -= UDP_WEIGHT_UNUSEFUL;
 
-  uns8 unuseful_value = g_fdip->get_warmed_up() ? 2 : 0;
-  auto it2 = useful_sequence.find(line_addr);
-  if (it2 == useful_sequence.end()) {
-    useful_sequence.insert(make_pair(line_addr, vector<uns8>()));
-    useful_sequence[line_addr].push_back(unuseful_value);
-  } else {
-    it2->second.push_back(unuseful_value);
+  if (FDIP_PRINT_CL_INFO) {
+    const uns8 unuseful_value = g_fdip->get_warmed_up() ? 2 : 0;
+    usefulness_history[line_addr].push_back(unuseful_value);
   }
 }
 
@@ -824,7 +821,7 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
       it->second++;
 
     if (FDIP_PRINT_CL_INFO)
-      sequence_aw[line_addr].push_back(make_pair('h', cycle_count));
+      cacheline_event_history[line_addr].push_back(make_pair('h', cycle_count));
 
     if (cur_line_delay) {
       auto it3 = per_line_delay_aw.find(line_addr);
@@ -836,15 +833,16 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
     }
     cur_line_delay = 0;
   } else {
-    warmup_events[line_addr] |= WARMUP_EVENT_h;
+    cacheline_events[line_addr] |= CACHELINE_EVENT_ICACHE_HIT;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 3 : 1;
-  auto it = icache_sequence.find(line_addr);
-  if (it == icache_sequence.end()) {
-    icache_sequence.insert(make_pair(line_addr, vector<uns8>()));
-    icache_sequence[line_addr].push_back(icache_val);
-  } else {
+  auto it = icache_access_history.find(line_addr);
+  if (it == icache_access_history.end()) {
+    icache_access_history.insert(make_pair(line_addr, vector<uns8>()));
+    if (FDIP_PRINT_CL_INFO)
+      icache_access_history[line_addr].push_back(icache_val);
+  } else if (FDIP_PRINT_CL_INFO) {
     it->second.push_back(icache_val);
   }
 }
@@ -1484,9 +1482,9 @@ void FDIP::assert_break_reason(Addr line_addr) {
 void FDIP::add_evict_seq(Addr line_addr) {
   if (warmed_up) {
     if (FDIP_PRINT_CL_INFO)
-      fdip_stat->sequence_aw[line_addr].push_back(make_pair('e', cycle_count));
+      fdip_stat->cacheline_event_history[line_addr].push_back(make_pair('e', cycle_count));
   } else {
-    fdip_stat->warmup_events[line_addr] |= FDIP_Stat::WARMUP_EVENT_e;
+    fdip_stat->cacheline_events[line_addr] |= FDIP_Stat::CACHELINE_EVENT_EVICTED;
   }
 }
 

--- a/src/prefetcher/fdip.cc
+++ b/src/prefetcher/fdip.cc
@@ -136,16 +136,16 @@ class FDIP_Stat {
   unordered_map<Addr, vector<uns8>> icache_sequence;
   // Before warmup, consumers only need to know whether each event type occurred;
   // a bitmask avoids retaining duplicate events, ordering, and cycle timestamps.
-  enum SequenceBwEvent : uint8_t {
-    BW_p = 1u << 0,
-    BW_P = 1u << 1,
-    BW_m = 1u << 2,
-    BW_h = 1u << 3,
-    BW_u = 1u << 4,
-    BW_U = 1u << 5,
-    BW_e = 1u << 6,
+  enum WarmupEvent : uint8_t {
+    WARMUP_EVENT_p = 1u << 0,
+    WARMUP_EVENT_P = 1u << 1,
+    WARMUP_EVENT_m = 1u << 2,
+    WARMUP_EVENT_h = 1u << 3,
+    WARMUP_EVENT_u = 1u << 4,
+    WARMUP_EVENT_U = 1u << 5,
+    WARMUP_EVENT_e = 1u << 6,
   };
-  unordered_map<Addr, uint8_t> sequence_bw;
+  unordered_map<Addr, uint8_t> warmup_events;
 
   // sequence_aw stores the complete per-cache-line event history required by
   // print_cl_info(), including event order, duplicates, and cycle timestamps.
@@ -638,7 +638,7 @@ void FDIP_Stat::inc_cnt_unuseful(Addr line_addr) {
     if (FDIP_PRINT_CL_INFO)
       sequence_aw[line_addr].push_back(make_pair('u', cycle_count));
   } else {
-    sequence_bw[line_addr] |= BW_u;
+    warmup_events[line_addr] |= WARMUP_EVENT_u;
   }
 }
 
@@ -668,7 +668,7 @@ void FDIP_Stat::inc_cnt_useful(Addr line_addr, Flag pref_miss) {
       sequence_aw[line_addr].push_back(make_pair('U', cycle_count));
     }
   } else {
-    sequence_bw[line_addr] |= BW_U;
+    warmup_events[line_addr] |= WARMUP_EVENT_U;
   }
 }
 
@@ -685,7 +685,7 @@ void FDIP_Stat::not_prefetch(Addr line_addr) {
       sequence_aw[line_addr].push_back(make_pair('p', onoff_cycle_count));
     }
   } else {
-    sequence_bw[line_addr] |= BW_p;
+    warmup_events[line_addr] |= WARMUP_EVENT_p;
   }
 }
 
@@ -710,7 +710,7 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
 
     cur_line_delay = cycle_count;
   } else {
-    sequence_bw[line_addr] |= BW_m;
+    warmup_events[line_addr] |= WARMUP_EVENT_m;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 2 : 0;
@@ -719,15 +719,15 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
     icache_sequence.insert(make_pair(line_addr, vector<uns8>()));
     icache_sequence[line_addr].push_back(icache_val);
     if (icache_val == 2) {
-      auto it2 = sequence_bw.find(line_addr);
-      if (it2 != sequence_bw.end()) {
+      auto it2 = warmup_events.find(line_addr);
+      if (it2 != warmup_events.end()) {
         STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_SEEN_DURING_WARMUP);
         const uint8_t state = it2->second;
-        const bool no_pref = state & BW_p;
-        // Preserve the legacy sequence_bw interpretation: lowercase 'u' drives
+        const bool no_pref = state & WARMUP_EVENT_p;
+        // Preserve the legacy before-warmup event interpretation: lowercase 'u' drives
         // the useful predicate, while uppercase 'U' drives the unuseful predicate.
-        const bool useful = state & BW_u;
-        const bool unuseful = state & BW_U;
+        const bool useful = state & WARMUP_EVENT_u;
+        const bool unuseful = state & WARMUP_EVENT_U;
         if (no_pref && !unuseful && !useful)
           STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_NO_PREF_DURING_WARMUP);
         if (!no_pref && unuseful && !useful)
@@ -787,7 +787,7 @@ void FDIP_Stat::inc_prefetched_cls(Addr line_addr, Flag on_path, uns success) {
       sequence_aw[line_addr].push_back(make_pair('P', onoff_cycle_count));
     }
   } else {
-    sequence_bw[line_addr] |= BW_P;
+    warmup_events[line_addr] |= WARMUP_EVENT_P;
   }
 }
 
@@ -836,7 +836,7 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
     }
     cur_line_delay = 0;
   } else {
-    sequence_bw[line_addr] |= BW_h;
+    warmup_events[line_addr] |= WARMUP_EVENT_h;
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 3 : 1;
@@ -1486,7 +1486,7 @@ void FDIP::add_evict_seq(Addr line_addr) {
     if (FDIP_PRINT_CL_INFO)
       fdip_stat->sequence_aw[line_addr].push_back(make_pair('e', cycle_count));
   } else {
-    fdip_stat->sequence_bw[line_addr] |= FDIP_Stat::BW_e;
+    fdip_stat->warmup_events[line_addr] |= FDIP_Stat::WARMUP_EVENT_e;
   }
 }
 

--- a/src/prefetcher/fdip.cc
+++ b/src/prefetcher/fdip.cc
@@ -25,6 +25,7 @@ extern "C" {
 #include <memory>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_FDIP, ##args)
 #define FDIP_PREF_STAT_COUNT 12
 
@@ -133,9 +134,10 @@ class FDIP_Stat {
   // Per-cache-line usefulness history emitted by print_cl_info(). The vectors
   // are populated only when FDIP_PRINT_CL_INFO is enabled.
   unordered_map<Addr, vector<uns8>> usefulness_history;
-  // Per-cache-line hit/miss history emitted by print_cl_info(). The vectors are
-  // populated only when FDIP_PRINT_CL_INFO is enabled, but map-entry existence
-  // is also used to identify a cache line's first recorded access.
+  // Tracks first recorded I-cache access independently of optional history output.
+  unordered_set<Addr> accessed_cachelines;
+  // Per-cache-line hit/miss history emitted by print_cl_info(). Allocate and
+  // populate entries only when FDIP_PRINT_CL_INFO is enabled.
   unordered_map<Addr, vector<uns8>> icache_access_history;
   // Consumers only need to know whether each cache-line event type occurred;
   // a bitmask avoids retaining duplicate events, ordering, and cycle timestamps.
@@ -713,11 +715,10 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 2 : 0;
-  auto it = icache_access_history.find(line_addr);
-  if (it == icache_access_history.end()) {
-    icache_access_history.insert(make_pair(line_addr, vector<uns8>()));
-    if (FDIP_PRINT_CL_INFO)
-      icache_access_history[line_addr].push_back(icache_val);
+  const bool first_access = accessed_cachelines.insert(line_addr).second;
+  if (FDIP_PRINT_CL_INFO)
+    icache_access_history[line_addr].push_back(icache_val);
+  if (first_access) {
     if (icache_val == 2) {
       auto it2 = cacheline_events.find(line_addr);
       if (it2 != cacheline_events.end()) {
@@ -738,8 +739,6 @@ void FDIP_Stat::inc_icache_miss(Addr line_addr) {
       } else
         STAT_EVENT(proc_id, ICACHE_FIRST_MISS_AFTER_WARMUP_NOT_SEEN_DURING_WARMUP);
     }
-  } else if (FDIP_PRINT_CL_INFO) {
-    it->second.push_back(icache_val);
   }
 }
 
@@ -837,14 +836,9 @@ void FDIP_Stat::inc_icache_hit(Addr line_addr) {
   }
 
   uns icache_val = g_fdip->get_warmed_up() ? 3 : 1;
-  auto it = icache_access_history.find(line_addr);
-  if (it == icache_access_history.end()) {
-    icache_access_history.insert(make_pair(line_addr, vector<uns8>()));
-    if (FDIP_PRINT_CL_INFO)
-      icache_access_history[line_addr].push_back(icache_val);
-  } else if (FDIP_PRINT_CL_INFO) {
-    it->second.push_back(icache_val);
-  }
+  accessed_cachelines.insert(line_addr);
+  if (FDIP_PRINT_CL_INFO)
+    icache_access_history[line_addr].push_back(icache_val);
 }
 
 /* FDIP member functions */


### PR DESCRIPTION
# Tables For Timing, Memory, Validation, & IPC at bottom.

# FDIP Memory-Retention Optimization Report

## 1. Scope and question

Heap profiling identified two FDIP allocation sites:

```text
28.88% (21,228,960 B) FDIP_Stat::not_prefetch(Addr)
 1.09%    (804,544 B) FDIP_Stat::inc_prefetched_cls(Addr, Flag, uns)
```

The investigation asked whether these allocations were a traditional leak, whether retained event history could be garbage-collected or compacted, and whether optional history could be disabled through an extended-statistics control. 

## 2. Reproducibility and experimental control

| Item | Value |
|:---|:---|
| Common repository revision | `fdef0d15113800491d778ed8785f9423a77e5661` |
| Official upstream revision checked | `d6c81a00bb69a1de52d7fad7120fa594660b9c86` |
| Baseline `fdip.cc` Git blob | `72435b72c1b135085e2e9e2626071e87d84cb31d` |
| Optimized `fdip.cc` Git blob | `1125347ba917ee5880940fbdbffa6de202e0321c` |
| Optimized FDIP diff SHA-256 | `93c4dca3ba9cde07f9c1002e7249cbbee2ac25b95d0c2f50ec4f1db5c64ede33` |
| Architecture configuration | `golden_cove` |
| Scarab build | `opt` |
| Simulation type | `memtrace` |
| Parameters override | Empty; both variants used the same configuration |
| Trial order | Baseline then optimized, repeated for each of five pairs |

### Workloads and traces

| Suite | Subsuite | Workload | Trace/cluster ID |
|:---|:---|:---|---:|
| SPEC CPU2017 | `rate_int_v2` | `perlbench_r` | 109678 |
| SPEC CPU2017 | `rate_int_v2` | `mcf_r` | 93581 |
| SPEC CPU2017 | `rate_fp_v2` | `lbm_r` | 107196 |

## 3. Exact simulator correctness

The automated comparison covered `*.stat.0.csv`, warmup statistics, text statistics, `PARAMS.in`, `PARAMS.out`, and `ramulator.stat.out` for every workload and repetition.

| Compared file pairs | Missing pairs | Different pairs | Verdict |
|---:|---:|---:|:---:|
| 585 | 0 | 0 | PASS |

```text
585 of 585 simulator-output file comparisons matched.
No simulated statistics changed.
PARAMS and Ramulator outputs matched byte-for-byte.
```

## 4. Memory behavior and data lifetime

The FDIP_Stat class records detailed statistics about cache-line activity, such as:
whether a line was prefetched
whether a prefetch was useful
cache hits and misses
evictions
when each event happened
whether the event occurred on-path or off-path
## Original implementation
<img width="1573" height="973" alt="image" src="https://github.com/user-attachments/assets/5a76fad3-1985-4cb5-b53d-77446399a857" />

Most of the information from the original implementation is not important. The main point is to look at the data structures that will be updated when it's called. The main data structures are sequence_aw & sequence_bw.

Sequence_bw is an unordered map with the data structure:
<unsigned long long, vector<pair<char, unsigned long long>>> 
An address with a data unsigned long long.
A vector consisting of pairs <char, unsigned long long>
A Char with a value of 'p ’: not prefetched, 'P': prefetched, 'm': icache miss, 'h': icache hit, 'u': useless, 'U': useful, 'e': eviction
The notable thing to know is that although the previous implementation saves all of the pairs in a vector that continuously grows, the reads that need the data only need a true or false to see whether these values were used. The only original reader is inside FDIP_Stat::inc_icache_miss():
## FDIP_Stat::inc_icache_miss():
<img width="1244" height="938" alt="image" src="https://github.com/user-attachments/assets/b673f026-6a28-4653-ab26-3e734495841c" />

## Optimized implementation
Instead of using a continuous vector, because sequence_bw is really a yes / no of have you seen these inside of the full [fdip.cc](http://fdip.cc/) file, you can use a bitmap to save the max amount of space, now i was going to use a type def for true and false, but i wanted to go above any beyond because why not and use a bitmap.
<img width="1784" height="443" alt="image" src="https://github.com/user-attachments/assets/3f0ff477-5929-4aa1-9ca2-b24f48eadc2d" />
<img width="1226" height="758" alt="image" src="https://github.com/user-attachments/assets/e94bded2-653f-4fe4-b553-181609cf6fa1" />

Now I do want to note that, for sequence_bw, the only things that get read are The Identity of 'p','u'& 'U'. So the writes to sequence_bw for the other classifications are redundant and a waste of space, but that's with the nuance that sequence_bw is kinda a mirror for sequence_aw, which does use the other classifiers. 


### `sequence_aw` 

<img width="841" height="39" alt="image" src="https://github.com/user-attachments/assets/623ac250-0703-4cbb-9f9d-f7ac5c4cb23a" />

This is kept as a vector, but the main changes are that we use the actual relevant control, `FDIP_PRINT_CL_INFO`. When it is false, the detailed history output is not requested, so optimized code does not populate `sequence_aw`. When it is true, full history remains available, and output semantics are preserved.
Inside of allbench_home/scarab/src/prefetcher/pref.param.def you can find 

<img width="903" height="43" alt="image" src="https://github.com/user-attachments/assets/6d3d3dd3-5f12-40aa-a713-e5f1ef2dc16a" />

An Example of this implementation will be for the function FDIP_Stat::inc_cnt_unuseful

## Original FDIP_Stat::inc_cnt_unuseful
<img width="1021" height="881" alt="image" src="https://github.com/user-attachments/assets/3a7fb0f3-a424-4cde-a333-b628f8a67fe5" />

## New FDIP_Stat::inc_cnt_unuseful
<img width="929" height="594" alt="image" src="https://github.com/user-attachments/assets/dbab7c5a-bfa4-4805-9198-ded9fcd11a5a" />

## 5. Algorithm and complexity

Let `A` be the number of distinct cache-line addresses and `E` the total number of recorded events, including duplicates.

| Property | Upstream vector history | Optimized bitmask |
|:---|:---|:---|
| Event update | Amortized O(1) vector append | Average O(1) map lookup and bitwise OR |
| Retained event payload | O(E) | O(A) |
| Duplicate events | Stored repeatedly | Coalesced into one bit |
| Ordering | Stored but not consumed for BW | Not stored |
| Cycle timestamp | Stored but not consumed for BW | Not stored |
| Dynamic vector growth | Yes | No per-address vector |

## 6. Repeated timing results

Five baseline and five optimized trials were run for each workload in paired alternating order. The individual measurements are in `fdip_timing_table.md`.

| Workload | Baseline median (s) | Optimized median (s) | Median paired improvement | Baseline min–max (s) | Optimized min–max (s) | Baseline sample SD (s) | Optimized sample SD (s) | Trials/version |
|:---|---:|---:|---:|---:|---:|---:|---:|---:|
| perlbench_r | 337.388593 | 331.474161 | 1.217% | 334.886568–366.320908 | 331.024824–365.191115 | 13.309458 | 14.715504 | 5 |
| mcf_r | 342.987157 | 342.476361 | 0.195% | 334.705374–359.303025 | 341.057170–357.846337 | 8.961717 | 7.015239 | 5 |
| lbm_r | 285.485820 | 283.990702 | 1.242% | 274.327671–295.253464 | 280.663608–294.613894 | 7.413069 | 5.498365 | 5 |

The geometric-mean speedup across all 15 paired workload trials is **0.337%**. Per workload, the geometric-mean changes are +1.304% for perlbench_r, -0.226% for mcf_r, and -0.059% for lbm_r.

The run-to-run variation is larger than the measured aggregate speed difference. Consequently, these data do not establish a statistically reliable CPU-speed improvement. The defensible performance claim is reduced memory with no simulated-behavior change.

## 7. Repeated peak-memory results

Docker-container memory was sampled every two seconds. These are approximate sampled peaks rather than exact allocator high-water marks.

| Workload | Baseline median peak (MiB) | Optimized median peak (MiB) | Median reduction | Trials/version |
|:---|---:|---:|---:|---:|
| perlbench_r | 98.64 | 90.60 | 8.151% | 5 |
| mcf_r | 99.38 | 32.51 | 67.287% | 5 |
| lbm_r | 99.25 | 32.59 | 67.164% | 5 |

The mcf_r and lbm_r reductions are consistent across all five trials. Perlbench_r baseline run 4 sampled only 71.57 MiB and is an outlier. 

## 8. Conclusion

```text
Correctness:
585 of 585 compared simulator-output file pairs matched. Instructions,
simulated cycles, IPC, PARAMS, Ramulator output, and all simulated statistics
were preserved. Only host wall-clock records were excluded from statistics
comparison.

Memory:
The upstream containers are not traditional lifetime leaks, but they retain
unbounded event history during simulation. sequence_bw can preserve its consumed
behavior with event-presence bits. sequence_aw collection can be disabled when
FDIP_PRINT_CL_INFO is false; exact history remains necessary when that output is
enabled. Median sampled peak memory fell by about 67% for mcf_r and lbm_r.

Performance:
Five paired trials per workload produced a 0.337% geometric-mean host-runtime
improvement across all 15 pairs, with variation too large to claim a reliable
CPU speedup. CPU perf evidence was not collected and no function-cycle claim is
made.

Scope:
No simulator behavior, configuration, trace, or simulated timing changed.
```
# FDIP IPC Correctness Results — All Five Paired Runs

| Run | Workload | Baseline instructions | Optimized instructions | Baseline cycles | Optimized cycles | Baseline IPC | Optimized IPC | Match |
|---:|:---|---:|---:|---:|---:|---:|---:|:---:|
| 1 | perlbench_r | 9,999,996 | 9,999,996 | 3,008,783 | 3,008,783 | 3.323601602 | 3.323601602 | Yes |
| 1 | mcf_r | 9,999,997 | 9,999,997 | 16,011,473 | 16,011,473 | 0.624551970 | 0.624551970 | Yes |
| 1 | lbm_r | 9,999,999 | 9,999,999 | 13,573,304 | 13,573,304 | 0.736740222 | 0.736740222 | Yes |
| 2 | perlbench_r | 9,999,996 | 9,999,996 | 3,008,783 | 3,008,783 | 3.323601602 | 3.323601602 | Yes |
| 2 | mcf_r | 9,999,997 | 9,999,997 | 16,011,473 | 16,011,473 | 0.624551970 | 0.624551970 | Yes |
| 2 | lbm_r | 9,999,999 | 9,999,999 | 13,573,304 | 13,573,304 | 0.736740222 | 0.736740222 | Yes |
| 3 | perlbench_r | 9,999,996 | 9,999,996 | 3,008,783 | 3,008,783 | 3.323601602 | 3.323601602 | Yes |
| 3 | mcf_r | 9,999,997 | 9,999,997 | 16,011,473 | 16,011,473 | 0.624551970 | 0.624551970 | Yes |
| 3 | lbm_r | 9,999,999 | 9,999,999 | 13,573,304 | 13,573,304 | 0.736740222 | 0.736740222 | Yes |
| 4 | perlbench_r | 9,999,996 | 9,999,996 | 3,008,783 | 3,008,783 | 3.323601602 | 3.323601602 | Yes |
| 4 | mcf_r | 9,999,997 | 9,999,997 | 16,011,473 | 16,011,473 | 0.624551970 | 0.624551970 | Yes |
| 4 | lbm_r | 9,999,999 | 9,999,999 | 13,573,304 | 13,573,304 | 0.736740222 | 0.736740222 | Yes |
| 5 | perlbench_r | 9,999,996 | 9,999,996 | 3,008,783 | 3,008,783 | 3.323601602 | 3.323601602 | Yes |
| 5 | mcf_r | 9,999,997 | 9,999,997 | 16,011,473 | 16,011,473 | 0.624551970 | 0.624551970 | Yes |
| 5 | lbm_r | 9,999,999 | 9,999,999 | 13,573,304 | 13,573,304 | 0.736740222 | 0.736740222 | Yes |

All 15 baseline/optimized IPC comparisons match exactly. The broader validation compared 585 simulator-output file pairs after excluding only `SIM_HOST_WALL_SECONDS`; zero pairs differed.
# FDIP Peak-Memory Results — All Five Paired Runs

Peak Docker-container memory was sampled every two seconds. These are approximate sampled peaks, not allocator-level exact peaks. A positive reduction means the optimized version used less memory.

| Run | Workload | Baseline peak (MiB) | Optimized peak (MiB) | Reduction (MiB) | Reduction |
|---:|:---|---:|---:|---:|---:|
| 1 | perlbench_r | 99.09 | 90.60 | 8.49 | 8.568% |
| 1 | mcf_r | 97.52 | 32.04 | 65.48 | 67.145% |
| 1 | lbm_r | 98.94 | 32.59 | 66.35 | 67.061% |
| 2 | perlbench_r | 97.50 | 92.76 | 4.74 | 4.862% |
| 2 | mcf_r | 99.52 | 32.51 | 67.01 | 67.333% |
| 2 | lbm_r | 99.62 | 32.55 | 67.07 | 67.326% |
| 3 | perlbench_r | 98.64 | 88.00 | 10.64 | 10.787% |
| 3 | mcf_r | 98.01 | 33.03 | 64.98 | 66.299% |
| 3 | lbm_r | 98.86 | 32.78 | 66.08 | 66.842% |
| 4 | perlbench_r | 71.57 | 90.64 | -19.07 | -26.645% |
| 4 | mcf_r | 99.38 | 32.17 | 67.21 | 67.629% |
| 4 | lbm_r | 99.97 | 32.78 | 67.19 | 67.210% |
| 5 | perlbench_r | 98.93 | 90.05 | 8.88 | 8.976% |
| 5 | mcf_r | 99.39 | 32.80 | 66.59 | 66.999% |
| 5 | lbm_r | 99.25 | 32.25 | 67.00 | 67.506% |

## Median summary

| Workload | Baseline median peak (MiB) | Optimized median peak (MiB) | Reduction (MiB) | Reduction |
|:---|---:|---:|---:|---:|
| perlbench_r | 98.64 | 90.60 | 8.04 | 8.151% |
| mcf_r | 99.38 | 32.51 | 66.87 | 67.287% |
| lbm_r | 99.25 | 32.59 | 66.66 | 67.164% |

The perlbench_r baseline measurement in run 4 is an outlier and should be disclosed rather than removed without a predefined exclusion rule. The mcf_r and lbm_r reductions are consistent across all five runs.
# FDIP Runtime Results — All Five Paired Runs

Times are host wall-clock seconds. A positive paired improvement means the optimized version was faster; a negative value means it was slower.

| Run | Workload | Baseline (s) | Optimized (s) | Paired improvement |
|---:|:---|---:|---:|---:|
| 1 | perlbench_r | 337.388593 | 365.191115 | -8.241% |
| 1 | mcf_r | 334.705374 | 357.846337 | -6.914% |
| 1 | lbm_r | 274.327671 | 294.613894 | -7.395% |
| 2 | perlbench_r | 346.104830 | 339.064348 | 2.034% |
| 2 | mcf_r | 343.756778 | 343.756576 | 0.000% |
| 2 | lbm_r | 285.603696 | 282.057201 | 1.242% |
| 3 | perlbench_r | 366.320908 | 331.148306 | 9.602% |
| 3 | mcf_r | 359.303025 | 342.476361 | 4.683% |
| 3 | lbm_r | 295.253464 | 284.575331 | 3.617% |
| 4 | perlbench_r | 334.886568 | 331.474161 | 1.019% |
| 4 | mcf_r | 342.629274 | 341.959623 | 0.195% |
| 4 | lbm_r | 285.485820 | 283.990702 | 0.524% |
| 5 | perlbench_r | 335.103048 | 331.024824 | 1.217% |
| 5 | mcf_r | 342.987157 | 341.057170 | 0.563% |
| 5 | lbm_r | 284.561222 | 280.663608 | 1.370% |

## Aggregate summary

| Workload | Baseline mean (s) | Baseline median (s) | Optimized mean (s) | Optimized median (s) | Improvement from medians | Median paired improvement |
|:---|---:|---:|---:|---:|---:|---:|
| perlbench_r | 343.960789 | 337.388593 | 339.580551 | 331.474161 | 1.753% | 1.217% |
| mcf_r | 344.676322 | 342.987157 | 345.419213 | 342.476361 | 0.149% | 0.195% |
| lbm_r | 285.046375 | 285.485820 | 285.180147 | 283.990702 | 0.524% | 1.242% |

These results show substantial host-runtime variation. The primary supported claim is memory reduction; more repetitions and controlled host conditions would be needed for a strong runtime-speedup claim.
# FDIP memory optimization validation

Generated: 2026-07-21T17:11:55-07:00

- Common repository commit: `fdef0d15113800491d778ed8785f9423a77e5661`
- Baseline FDIP blob from official upstream/main: `72435b72c1b135085e2e9e2626071e87d84cb31d`
- Optimized working-tree commit: `fdef0d15113800491d778ed8785f9423a77e5661` plus the local FDIP changes
- Paired repetitions: 5
- Workloads: perlbench_r/109678, mcf_r/93581, lbm_r/107196

## Correctness

| Compared file pairs | Missing pairs | Different pairs | Verdict |
|---:|---:|---:|:---|
| 585 | 0 | 0 | PASS |

All Scarab statistics were compared after excluding only `SIM_HOST_WALL_SECONDS`.
Parameter files and Ramulator outputs were compared byte-for-byte.

## Host wall time

| Workload | Baseline mean (s) | Baseline median (s) | Optimized mean (s) | Optimized median (s) | Median improvement |
|:---|---:|---:|---:|---:|---:|
| perlbench_r | 343.960789 | 337.388593 | 339.580551 | 331.474161 | 1.753% |
| mcf_r | 344.676322 | 342.987157 | 345.419213 | 342.476361 | 0.149% |
| lbm_r | 285.046375 | 285.485820 | 285.180147 | 283.990702 | 0.524% |

## Peak Docker-container memory

Peak memory was sampled every two seconds while each Scarab container ran. Values are medians across paired runs.

| Workload | Baseline peak (MiB) | Optimized peak (MiB) | Reduction (MiB) | Reduction |
|:---|---:|---:|---:|---:|
| perlbench_r | 98.640000 | 90.600000 | 8.040 | 8.151% |
| mcf_r | 99.380000 | 32.510000 | 66.870 | 67.287% |
| lbm_r | 99.250000 | 32.590000 | 66.660 | 67.164% |

## Container-lifetime findings

| Question | Evidence-based answer |
|:---|:---|
| Traditional leak? | No. The containers are owned by FDIP_Stat and are destroyed with that object. |
| Unbounded retention? | Yes in upstream: per-line vectors append events for the duration of their phase with no erase, clear, or size bound. |
| Can sequence_bw be compacted? | Yes. Its consumer needs event presence, so the optimized uint8_t mask preserves consumed behavior. |
| Can sequence_aw events be garbage-collected? | Not while exact extended history is requested; order, duplicates, and timestamps feed per_line_seq_aw.csv. |
| Can sequence_aw be disabled? | Yes when FDIP_PRINT_CL_INFO is false. The optimized code does not populate it in that mode. |
| FDIP_EXTENDED_STATS? | No parameter or compile-time symbol with that name exists in this checkout. The real consumer flag is FDIP_PRINT_CL_INFO. |

## What I learned.
Most honestly, I was really happy with this result. I was relying on perf for all of my recording stuff. Still, then I learned about heaptrack; I need to dive into the other tooling categories to figure out what I can find out about a program, but for now this was nice. I think I will focus extra hard on the data structures again; I'm done with this piece. Still, I would like to see that the values for the bitmap can be on the stack. Still, for the unordered map it's going to be on the heap, which is slower. If there's a way to convert that to a linear structure, that would be great, and I'm sure there is, but I'm done with this for now; that's a thought for my next optimization. 

Fixes #466