### PR TITLE
Build opt-avx for 256-bit AVX2 (-march=haswell) instead of AVX-512

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,11 +22,18 @@ if(DEFINED ENV{SCARAB_ENABLE_PT_MEMTRACE})
   set(flags_enable_pt_memtrace "-DENABLE_PT_MEMTRACE")
 endif()
 
-# SCARABOPT: -O3 portable x86-64 (make opt). OPT_AVX: same + -march=skylake-avx512 (make opt-avx).
+# SCARABOPT: -O3 portable x86-64 (make opt). OPT_AVX: same + -march=haswell (make opt-avx).
+#
+# OPT_AVX targets haswell (256-bit AVX2, FMA, BMI2) rather than skylake-avx512.
+# -march=skylake-avx512 emits AVX-512 instructions, so the resulting binary dies
+# with SIGILL ("Illegal instruction") on any host without AVX-512 -- including all
+# AMD Zen hosts. haswell is the widest baseline that every x86-64 machine from
+# Haswell/Zen1 onward can execute, which keeps one build usable across a
+# heterogeneous cluster instead of silently restricting it to Intel nodes.
 set(CMAKE_C_FLAGS_SCARABOPT "-O3 -g3 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
 set(CMAKE_CXX_FLAGS_SCARABOPT "-O3 -g3 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
-set(CMAKE_C_FLAGS_OPT_AVX "-O3 -g3 -march=skylake-avx512 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
-set(CMAKE_CXX_FLAGS_OPT_AVX "-O3 -g3 -march=skylake-avx512 -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
+set(CMAKE_C_FLAGS_OPT_AVX "-O3 -g3 -march=haswell -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
+set(CMAKE_CXX_FLAGS_OPT_AVX "-O3 -g3 -march=haswell -DNO_DEBUG -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
 
 set(CMAKE_C_FLAGS_VALGRIND    "-O0 -g3 -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")
 set(CMAKE_CXX_FLAGS_VALGRIND  "-O0 -g3 -DLINUX -DX86_64 ${flags_enable_pt_memtrace}")

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ opt: BUILD_TYPE = SCARABOPT
 opt: $(BUILD_DIR_PREFIX)/opt/scarab_phony ## Build Scarab optimized (-O3 -g3), portable x86-64 (no -march)
 
 opt-avx: BUILD_TYPE = OPT_AVX
-opt-avx: $(BUILD_DIR_PREFIX)/opt-avx/scarab_phony ## Same as opt with -march=skylake-avx512
+opt-avx: $(BUILD_DIR_PREFIX)/opt-avx/scarab_phony ## Same as opt with -march=haswell (256-bit AVX2; runs on Intel and AMD)
 
 dbg: BUILD_TYPE := Debug
 dbg: $(BUILD_DIR_PREFIX)/dbg/scarab_phony ## Build Scarab in debug mode


### PR DESCRIPTION
## Problem

`opt-avx` was compiled with `-march=skylake-avx512`, which emits AVX-512 instructions. The binary therefore dies instantly with `SIGILL` on any host without AVX-512 — including every AMD Zen machine:

```
Illegal instruction (core dumped) .../scarab_current --frontend memtrace ...
```

On a mixed cluster this silently limits `opt-avx` to Intel nodes. It is also easy to misdiagnose, because the job wrapper still exits 0 after the crash, so slurm records the job as `COMPLETED` with no stats rather than as a failure.

## Change

`OPT_AVX` now uses `-march=haswell` — 256-bit AVX2 with FMA and BMI2. That is the widest baseline every x86-64 host from Haswell / Zen1 onward can execute, so a single build runs on the whole cluster.

`-march=x86-64-v3` would express the same level more idiomatically, but the build container ships gcc 9.4, which does not accept it.

## Verification

Ran the identical 1M-instruction `gcc_r` memtrace simulation on all six nodes of a mixed cluster:

| node | CPU | AVX-512 | before | after |
|---|---|---|---|---|
| bohr2 | Xeon Gold 5117 | yes | pass | pass |
| bohr3 | Xeon Gold 5117 | yes | pass | pass |
| bohr4 | Xeon Gold 5218 | yes | pass | pass |
| ohm | Xeon Gold 6242R | yes | pass | pass |
| twilight | AMD EPYC 7452 | no | **SIGILL** | pass |
| dennard | AMD EPYC 7452 | no | **SIGILL** | pass |

All six produce byte-identical results — 802104 cycles, 1007338 instructions, IPC 1.256 — so the ISA change does not perturb simulation output.

Also confirmed with `objdump` that the old `opt-avx` binary contained 56 AVX-512 register references while a `-march=haswell` build contains none, and that a probe compiled `-march=skylake-avx512` reproduces the `SIGILL` on EPYC while the `-march=haswell` probe runs cleanly.

## Note

Performance of the simulator itself on AVX-512-capable Intel hosts may differ slightly, since 512-bit vectorization is no longer available to the compiler. This affects scarab's own execution speed, not simulated results. If maximum host throughput on Intel matters, a separate `opt-avx512` target could be added rather than making the portable build Intel-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)