### PR TITLE
dcache: skip re-lookup for OS_WAIT_MEM re-probes + tighten dcache_cycle stamp

### DIFF
--- a/src/dcache_stage.c
+++ b/src/dcache_stage.c
@@ -234,6 +234,21 @@ void update_dcache_stage(Stage_Data* src_sd) {
       continue;
     }
 
+    // OS_WAIT_MEM re-probe: the op already accessed the dcache and missed, and
+    // new_mem_req found no in-flight request to merge with and no free mem-request
+    // buffer. Re-looking-up the dcache can only re-derive the same known miss, so skip
+    // the port acquisition and the tag lookup entirely and go straight to retrying the
+    // mem request. A matching in-flight request that shows up later is still caught by
+    // new_mem_req's queue search inside the miss handler. Set OS_SCHEDULED first (as the
+    // fresh-access path below does) so the store-forward-hit case, which does not set
+    // op->state, leaves the op removable instead of resident.
+    if (op->state == OS_WAIT_MEM) {
+      ASSERT(dc->proc_id, op_get_dcache_cycle(op) != MAX_CTR);
+      op->state = OS_SCHEDULED;
+      dcache_cacheline_miss(op, get_cache_line_addr(&dc->dcache, op->oracle_info.va));
+      continue;
+    }
+
     /* check on the availability of a read port for the given bank */
     // the bank bits are the lowest order cache index bits
     uns bank = BANK(op->oracle_info.va, DCACHE_BANKS, DCACHE_INTERLEAVE_FACTOR);
@@ -245,18 +260,13 @@ void update_dcache_stage(Stage_Data* src_sd) {
       STAT_EVENT(dc->proc_id, DCACHE_READ_PORT_UNAVAILABLE_ONPATH + op->off_path);
       continue;
     }
-    // Record the op's first dcache access (dcache_cycle gates precommit). op->state
-    // is still the entry state here (set OS_SCHEDULED below). If dcache_cycle is not
-    // yet set, this is that first access -- stamp it. If it is already set, this must
-    // be a re-probe from one of the two states phase 1 keeps resident (see the
-    // retention check above): OS_WAIT_MEM (missed, waiting for a mem-request buffer,
-    // already accessed+stamped) or OS_WAIT_DCACHE (a stamped OS_WAIT_MEM op that
-    // re-probed into a busy port -- the only path by which a stamped op re-enters
-    // OS_WAIT_DCACHE; a *fresh* OS_WAIT_DCACHE is unstamped and takes the branch above).
-    if (op_get_dcache_cycle(op) == MAX_CTR)
-      op_set_dcache_cycle(op, cycle_count);
-    else
-      ASSERT(dc->proc_id, op->state == OS_WAIT_DCACHE || op->state == OS_WAIT_MEM);
+    // Record the op's first dcache access (dcache_cycle gates precommit). Every op
+    // reaching here is making that first access: fresh from the scheduler, or an
+    // OS_WAIT_DCACHE op that was only ever waiting for a cache port and never accessed.
+    // OS_WAIT_MEM re-probes are short-circuited above, so a stamped op can no longer
+    // re-enter this point (the sole path was OS_WAIT_MEM -> busy port -> OS_WAIT_DCACHE);
+    // op_set_dcache_cycle is write-once and asserts dcache_cycle was unset.
+    op_set_dcache_cycle(op, cycle_count);
 
     // memory ops are marked as scheduled so that they can be removed from the node->rdy_list
     op->state = OS_SCHEDULED;


### PR DESCRIPTION
Follow-up to #553 (based on `refactor-cycle-counters`; rebase onto `main` once #553 lands). Single commit.

## What
A memory op that misses and can't get a mem-request buffer parks in `OS_WAIT_MEM` and re-probes the dcache every cycle. `new_mem_req` searches all queues and **merges before** it ever returns "no buffer", so `OS_WAIT_MEM` means *a known miss with no in-flight request to merge into*. The old re-probe still re-ran the full access — acquire a port, look up the tag, re-derive the same miss — burning a dcache port each cycle (and able to bounce the op through `OS_WAIT_DCACHE`) without ever changing the outcome.

This short-circuits `OS_WAIT_MEM` re-probes straight into the miss handler (retry `new_mem_req` only), skipping the port acquisition and the tag lookup. `line_addr` comes from the side-effect-free `get_cache_line_addr`. A merge partner that appears later is still caught by `new_mem_req`'s own queue search. `OS_SCHEDULED` is set first (as the fresh-access path does) so the store-forward-hit case — which leaves `op->state` untouched — stays removable rather than resident.

## Why it also tightens the dcache_cycle stamp
Removing the re-probe eliminates the **only** path by which a stamped op re-enters `OS_WAIT_DCACHE` (`OS_WAIT_MEM` → busy port → `OS_WAIT_DCACHE`). So every op reaching the stamp site is now on its unique first access, and the guard tightens from "stamp-if-unset, else assert a re-probe state" (the #553-safe form) back to strict "assert unset, set once."

## Not a no-op
Fewer dcache port acquisitions + no redundant re-lookup → this changes timing. Validated for IPC drift on the full SPEC2017 memtrace sweep (`json/spec17_skip_relookup.json`, baseline = the #553 binary) — results to follow in a comment. Kept separate from #553 precisely because #553 must stay a functional no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)