### PR TITLE
pin_exec: fix hyper-FF exception mailbox assert (exec-driven)

### DIFF
--- a/src/pin/pin_exec/exception_handling.cc
+++ b/src/pin/pin_exec/exception_handling.cc
@@ -80,7 +80,12 @@ bool signal_handler(THREADID tid, INT32 sig, CONTEXT* ctxt, bool hasHandler,
             "signalhandler curr_uid=%" PRIu64 ", curr_eip=%" PRIx64
             ", sig=%d, wp=%d\n",
             uid_ctr, (uint64_t)curr_eip, sig, on_wrongpath);
-  if(!fast_forward_count || on_wrongpath) {
+  // During hyper fast-forward, fast_forward_count is 0 (only hyper_fast_forward_count
+  // counts down), so an app exception here must NOT be processed as a simulated
+  // right-path exception -- no op was staged into the mailbox yet, so the first
+  // do_fe_null would assert "Expected full mailbox". Treat hyper-FF like regular FF
+  // (fall through, deliver to the app).
+  if ((!fast_forward_count && !hyper_ff) || on_wrongpath) {
     if(on_wrongpath) {
       if(sig == SIGFPE || sig == SIGSEGV || sig == SIGBUS) {
         PIN_SetContextRegval(ctxt, REG_INST_PTR, (const UINT8*)(&next_eip));


### PR DESCRIPTION
Single commit on `main` (#556 has landed).

## Bug
Exec-driven SPEC2017 runs abort at the first simulated op with
`main_loop.cc:340: ASSERT FAILED: Expected full mailbox for exc @ 0`. Reproduces on plain `main` (baseline, no LVP) — all `rate_fp_v2` and many `rate_int_v2` simpoints.

## Root cause
During **hyper** fast-forward, `fast_forward_count == 0` (only `hyper_fast_forward_count` counts down). The signal-handler gate `if(!fast_forward_count || on_wrongpath)` therefore treats an app exception *during* hyper-FF as a simulated right-path exception and sets `pending_exception` — but hyper-FF never stages an op into `op_mailbox`, so the first `do_fe_null` asserts an empty mailbox. Regular FF (`fast_forward_count > 0`) already falls through and delivers the signal to the app; hyper-FF was simply mis-gated.

## Fix
Exclude hyper-FF from the gate: `if((!fast_forward_count && !hyper_ff) || on_wrongpath)`. One line; hyper-FF now handles exceptions exactly like regular FF.

## Validation
On the exact failing simpoint (`rate_int_v2/xz_r_3/36264`) the mailbox assert is gone — `pin.err` shows the exception falling through (`Found exception ... on rightpath`) and PIN reaching `End of program`. A full SPEC2017 exec-driven baseline sweep is running; results to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)