### PR TITLE
pin_exec: deliver loaded value to the load uop (capture memory data at IPOINT_BEFORE)

### DIFF
--- a/src/ctype_pin_inst.h
+++ b/src/ctype_pin_inst.h
@@ -136,9 +136,7 @@ typedef struct ctype_pin_inst_struct {
   Pin_Reg_Val dests[MAX_DESTS];
   uint64_t ld_vaddr[MAX_LD_NUM];
   uint64_t st_vaddr[MAX_ST_NUM];
-  // Loaded data value (zero-extended, scalar loads <= 8 bytes; 0 for wider loads),
-  // captured at IPOINT_BEFORE so read-modify-write loads see the pre-store value.
-  uint64_t ld_data[MAX_LD_NUM];
+  uint64_t ld_data[MAX_LD_NUM];  // loaded value (scalar <=8B, captured at IPOINT_BEFORE; 0 for wider)
   uint8_t ld_size;
   uint8_t st_size;
 

--- a/src/ctype_pin_inst.h
+++ b/src/ctype_pin_inst.h
@@ -136,6 +136,9 @@ typedef struct ctype_pin_inst_struct {
   Pin_Reg_Val dests[MAX_DESTS];
   uint64_t ld_vaddr[MAX_LD_NUM];
   uint64_t st_vaddr[MAX_ST_NUM];
+  // Loaded data value (zero-extended, scalar loads <= 8 bytes; 0 for wider loads),
+  // captured at IPOINT_BEFORE so read-modify-write loads see the pre-store value.
+  uint64_t ld_data[MAX_LD_NUM];
   uint8_t ld_size;
   uint8_t st_size;
 

--- a/src/inst_info.h
+++ b/src/inst_info.h
@@ -41,6 +41,7 @@ typedef struct Reg_Info_struct {
   Reg_Type type;  // integer, floating point, extra
   uns16 id;       // flattened register number (unique across sets)
   uint64_t val;   // runtime register value (valid only in dynamic/Trace_Uop context)
+  Flag val_valid;  // whether val has been written (a 0 val does not imply "unwritten")
 } Reg_Info;
 
 /**************************************************************************************/

--- a/src/pin/pin_lib/decoder.cc
+++ b/src/pin/pin_lib/decoder.cc
@@ -285,9 +285,10 @@ void create_compressed_op(ADDRINT iaddr) {
                                          num_lds, filled_inst_info);
     }
     assert(filled_inst_info->num_ld == num_lds);
+    assert(glb_ld_data.size() == glb_ld_vaddrs.size());
     for(uint ld = 0; ld < num_lds; ld++) {
       filled_inst_info->ld_vaddr[ld] = glb_ld_vaddrs[ld];
-      filled_inst_info->ld_data[ld] = (ld < glb_ld_data.size()) ? glb_ld_data[ld] : 0;
+      filled_inst_info->ld_data[ld] = glb_ld_data[ld];
     }
 
     uint num_sts = glb_st_vaddrs.size();
@@ -318,6 +319,8 @@ void create_compressed_op(ADDRINT iaddr) {
   // heartbeat += 1;
 }
 
+static uint64_t read_ld_data(ADDRINT addr, UINT32 size);
+
 void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
                             PIN_MULTI_MEM_ACCESS_INFO* mem_access_info) {
   const vector<PIN_MEM_ACCESS_INFO> gather_scatter_mem_access_infos =
@@ -344,8 +347,10 @@ void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
     // only let Scarab know about it if the memop is not masked away
     if(mask_on) {
       if (is_load) {
+        // Each gather element access is scalar-sized; capture it like a normal load
+        // (read_ld_data zero-fills anything > 8 bytes).
         glb_ld_vaddrs.push_back(addr);
-        glb_ld_data.push_back(0);  // gather loads are vector (> 8 bytes); value not captured
+        glb_ld_data.push_back(read_ld_data(addr, gather_scatter_mem_access_infos[i].bytesAccessed));
       } else
         glb_st_vaddrs.push_back(addr);
     }

--- a/src/pin/pin_lib/decoder.cc
+++ b/src/pin/pin_lib/decoder.cc
@@ -55,6 +55,7 @@ static ctype_pin_inst  tmp_inst_info;
 // Globals used for communication between analysis functions
 uint32_t       glb_opcode, glb_actually_taken;
 deque<ADDRINT> glb_ld_vaddrs, glb_st_vaddrs;
+deque<uint64_t> glb_ld_data;  // loaded value per load, captured at IPOINT_BEFORE (kept aligned with glb_ld_vaddrs)
 deque<Pin_Reg_Val> glb_src_vector_vals, glb_dst_vector_vals;
 
 std::ostream*                                    glb_err_ostream;
@@ -84,8 +85,8 @@ void print_err_if_invalid(ctype_pin_inst* info, const INS& ins);
 void get_opcode(UINT32 opcode);
 void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
                             PIN_MULTI_MEM_ACCESS_INFO* mem_access_info);
-void get_ld_ea(ADDRINT addr);
-void get_ld_ea2(ADDRINT addr1, ADDRINT addr2);
+void get_ld_ea(ADDRINT addr, UINT32 size);
+void get_ld_ea2(ADDRINT addr1, ADDRINT addr2, UINT32 size);
 void get_st_ea(ADDRINT addr);
 void get_branch_dir(bool taken);
 void get_src_vector_vals(CONTEXT* ctxt, ADDRINT reg_id, ADDRINT scarab_id);
@@ -192,11 +193,10 @@ void insert_analysis_functions(ctype_pin_inst* info, const INS& ins) {
   } else {
     if(INS_IsMemoryRead(ins)) {
       if(INS_HasMemoryRead2(ins)) {
-        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)get_ld_ea2,
-                       IARG_MEMORYREAD_EA, IARG_MEMORYREAD2_EA, IARG_END);
+        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)get_ld_ea2, IARG_MEMORYREAD_EA, IARG_MEMORYREAD2_EA,
+                       IARG_MEMORYREAD_SIZE, IARG_END);
       } else {
-        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)get_ld_ea,
-                       IARG_MEMORYREAD_EA, IARG_END);
+        INS_InsertCall(ins, IPOINT_BEFORE, (AFUNPTR)get_ld_ea, IARG_MEMORYREAD_EA, IARG_MEMORYREAD_SIZE, IARG_END);
       }
     }
 
@@ -287,6 +287,7 @@ void create_compressed_op(ADDRINT iaddr) {
     assert(filled_inst_info->num_ld == num_lds);
     for(uint ld = 0; ld < num_lds; ld++) {
       filled_inst_info->ld_vaddr[ld] = glb_ld_vaddrs[ld];
+      filled_inst_info->ld_data[ld] = (ld < glb_ld_data.size()) ? glb_ld_data[ld] : 0;
     }
 
     uint num_sts = glb_st_vaddrs.size();
@@ -306,6 +307,7 @@ void create_compressed_op(ADDRINT iaddr) {
   glb_dst_vector_vals.clear();
   glb_src_vector_vals.clear();
   glb_ld_vaddrs.clear();
+  glb_ld_data.clear();
   glb_st_vaddrs.clear();
   glb_actually_taken = 0;
 
@@ -341,9 +343,10 @@ void get_gather_scatter_eas(bool is_gather, CONTEXT* ctxt,
 
     // only let Scarab know about it if the memop is not masked away
     if(mask_on) {
-      if(is_load)
+      if (is_load) {
         glb_ld_vaddrs.push_back(addr);
-      else
+        glb_ld_data.push_back(0);  // gather loads are vector (> 8 bytes); value not captured
+      } else
         glb_st_vaddrs.push_back(addr);
     }
   }
@@ -353,13 +356,25 @@ void get_opcode(UINT32 opcode) {
   glb_opcode = opcode;
 }
 
-void get_ld_ea(ADDRINT addr) {
-  glb_ld_vaddrs.push_back(addr);
+// Read the loaded value now (IPOINT_BEFORE), so read-modify-write loads observe the
+// pre-store memory. Only scalar loads (<= 8 bytes) are captured; wider loads store 0.
+static uint64_t read_ld_data(ADDRINT addr, UINT32 size) {
+  uint64_t val = 0;
+  if (size && size <= 8)
+    PIN_SafeCopy(&val, (const void*)addr, size);
+  return val;
 }
 
-void get_ld_ea2(ADDRINT addr1, ADDRINT addr2) {
+void get_ld_ea(ADDRINT addr, UINT32 size) {
+  glb_ld_vaddrs.push_back(addr);
+  glb_ld_data.push_back(read_ld_data(addr, size));
+}
+
+void get_ld_ea2(ADDRINT addr1, ADDRINT addr2, UINT32 size) {
   glb_ld_vaddrs.push_back(addr1);
   glb_ld_vaddrs.push_back(addr2);
+  glb_ld_data.push_back(read_ld_data(addr1, size));
+  glb_ld_data.push_back(read_ld_data(addr2, size));
 }
 
 void get_st_ea(ADDRINT addr) {

--- a/src/pin/pin_lib/uop_generator.c
+++ b/src/pin/pin_lib/uop_generator.c
@@ -968,6 +968,11 @@ void convert_dyn_uop(uns8 proc_id, Inst_Info* info, ctype_pin_inst* pi, Trace_Uo
       trace_uop->load_seq_num = info->trace_info.load_seq_num;
       ASSERT(proc_id, trace_uop->load_seq_num < MAX_LD_NUM);
       trace_uop->va = pi->ld_vaddr[trace_uop->load_seq_num];
+      // The loaded value is the memory data (captured at IPOINT_BEFORE), not a destination
+      // register value: a cracked load-op writes an internal temp (REG_TMP0) that PIN has no
+      // architectural destination for, so the dst-reg match above leaves it 0. Take it from ld_data.
+      for (uns ii = 0; ii < info->table_info.num_dest_regs; ii++)
+        trace_uop->dests[ii].val = pi->ld_data[trace_uop->load_seq_num];
       DEBUG(proc_id,
             "Generating a load: inst @%llx opcode: %s num_ld: %i "
             "num_st: %u va: 0x%s load size: %u\n",

--- a/src/pin/pin_lib/uop_generator.c
+++ b/src/pin/pin_lib/uop_generator.c
@@ -942,9 +942,15 @@ void convert_dyn_uop(uns8 proc_id, Inst_Info* info, ctype_pin_inst* pi, Trace_Uo
   }
   for (uns ii = 0; ii < info->table_info.num_dest_regs; ii++) {
     trace_uop->dests[ii].val = 0;
+    trace_uop->dests[ii].val_valid = FALSE;
+    // A load's produced value comes from ld_data (MEM_LD block below), not the architectural
+    // dst-reg match; skip it here so the destination value is written exactly once.
+    if (info->table_info.mem_type == MEM_LD)
+      continue;
     for (uns j = 0; j < pi->num_dst_regs; j++) {
       if (pi->dst_regs[j] == info->dests[ii].id) {
         trace_uop->dests[ii].val = pi->dests[j].val;
+        trace_uop->dests[ii].val_valid = TRUE;
         break;
       }
     }
@@ -968,15 +974,16 @@ void convert_dyn_uop(uns8 proc_id, Inst_Info* info, ctype_pin_inst* pi, Trace_Uo
       trace_uop->load_seq_num = info->trace_info.load_seq_num;
       ASSERT(proc_id, trace_uop->load_seq_num < MAX_LD_NUM);
       trace_uop->va = pi->ld_vaddr[trace_uop->load_seq_num];
-      // The loaded value is the memory data (captured at IPOINT_BEFORE); it overrides the dst-reg
-      // match above, which leaves 0 for a cracked load-op whose load uop writes the internal
-      // REG_TMP0 (no architectural destination for PIN to report). A load uop has a single
-      // destination -- its loaded value -- so this cannot clobber another matched register.
+      // The loaded value is the memory data (captured at IPOINT_BEFORE). The dst-reg match above
+      // deliberately skips load uops, so the value is written here exactly once -- val_valid must
+      // be false (a cracked load-op writes the internal REG_TMP0, which PIN has no arch dest for).
       ASSERT(proc_id, trace_uop->load_seq_num < pi->num_ld);
-      ASSERT(proc_id, info->table_info.num_dest_regs <= 1);
       const uns64 ld_val = pi->ld_data[trace_uop->load_seq_num];
-      for (uns ii = 0; ii < info->table_info.num_dest_regs; ii++)
+      for (uns ii = 0; ii < info->table_info.num_dest_regs; ii++) {
+        ASSERT(proc_id, !trace_uop->dests[ii].val_valid);  // a destination value is written exactly once
         trace_uop->dests[ii].val = ld_val;
+        trace_uop->dests[ii].val_valid = TRUE;
+      }
       DEBUG(proc_id,
             "Generating a load: inst @%llx opcode: %s num_ld: %i "
             "num_st: %u va: 0x%s load size: %u\n",

--- a/src/pin/pin_lib/uop_generator.c
+++ b/src/pin/pin_lib/uop_generator.c
@@ -949,6 +949,7 @@ void convert_dyn_uop(uns8 proc_id, Inst_Info* info, ctype_pin_inst* pi, Trace_Uo
       continue;
     for (uns j = 0; j < pi->num_dst_regs; j++) {
       if (pi->dst_regs[j] == info->dests[ii].id) {
+        ASSERT(proc_id, !trace_uop->dests[ii].val_valid);  // a destination value is written exactly once
         trace_uop->dests[ii].val = pi->dests[j].val;
         trace_uop->dests[ii].val_valid = TRUE;
         break;

--- a/src/pin/pin_lib/uop_generator.c
+++ b/src/pin/pin_lib/uop_generator.c
@@ -968,11 +968,15 @@ void convert_dyn_uop(uns8 proc_id, Inst_Info* info, ctype_pin_inst* pi, Trace_Uo
       trace_uop->load_seq_num = info->trace_info.load_seq_num;
       ASSERT(proc_id, trace_uop->load_seq_num < MAX_LD_NUM);
       trace_uop->va = pi->ld_vaddr[trace_uop->load_seq_num];
-      // The loaded value is the memory data (captured at IPOINT_BEFORE), not a destination
-      // register value: a cracked load-op writes an internal temp (REG_TMP0) that PIN has no
-      // architectural destination for, so the dst-reg match above leaves it 0. Take it from ld_data.
+      // The loaded value is the memory data (captured at IPOINT_BEFORE); it overrides the dst-reg
+      // match above, which leaves 0 for a cracked load-op whose load uop writes the internal
+      // REG_TMP0 (no architectural destination for PIN to report). A load uop has a single
+      // destination -- its loaded value -- so this cannot clobber another matched register.
+      ASSERT(proc_id, trace_uop->load_seq_num < pi->num_ld);
+      ASSERT(proc_id, info->table_info.num_dest_regs <= 1);
+      const uns64 ld_val = pi->ld_data[trace_uop->load_seq_num];
       for (uns ii = 0; ii < info->table_info.num_dest_regs; ii++)
-        trace_uop->dests[ii].val = pi->ld_data[trace_uop->load_seq_num];
+        trace_uop->dests[ii].val = ld_val;
       DEBUG(proc_id,
             "Generating a load: inst @%llx opcode: %s num_ld: %i "
             "num_st: %u va: 0x%s load size: %u\n",


### PR DESCRIPTION
## Problem
A cracked **load-op** macro (`add rax,[mem]`, `cmp`, indirect `jmp [mem]`, RMW stores, …) splits into a load µop + a consumer µop joined by scarab's internal temp `REG_TMP0`. The load µop therefore writes `REG_TMP0`, which has **no architectural destination register**, so PIN never supplies a value for it and `convert_dyn_uop`'s dst-reg id-match leaves `op->dst_val = 0`. Only pure `mov reg,[mem]`/`pop` loads (dest = real GPR) received values.

Net: in exec-driven mode the loaded value is unavailable for the majority of loads (empirically ~98–100% of predicted loads read as 0 on mcf/xz), which makes any load-value consumer see zeros rather than real data.

## Fix
Capture the loaded data directly from memory at **IPOINT_BEFORE** (so read-modify-write loads observe the pre-store value), carry it per-load in `ctype_pin_inst.ld_data[]`, and assign it as the load µop's produced value in `convert_dyn_uop` regardless of which register the load writes. Scalar loads only (≤ 8 bytes); wider (vector) loads store 0.

- `ctype_pin_inst.h`: add `ld_data[MAX_LD_NUM]`.
- `decoder.cc`: `get_ld_ea`/`get_ld_ea2` `PIN_SafeCopy` the read value (IPOINT_BEFORE), kept aligned with `glb_ld_vaddrs`; filled into `ld_data[]` in `create_compressed_op`.
- `uop_generator.c`: load µop's dest value sourced from `ld_data[load_seq_num]`.

## Verification
Load µops whose dest is `REG_TMP0` (id 78) now carry the real memory value (e.g. `0x555556252cc0`) instead of 0; ~82% nonzero on gcc_r_3 (remaining zeros are genuine 0-valued loads). Builds and runs crash-free.

Note: the PIN tool Makefile does not track `ctype_pin_inst.h` as a dependency, so an incremental build after this struct change needs a clean pin rebuild (CI's clean build is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)