### PR TITLE
pin build: track header deps for tool + pin_lib objects (-MMD)

### DIFF
--- a/src/pin/pin_exec/makefile.rules
+++ b/src/pin/pin_exec/makefile.rules
@@ -91,10 +91,10 @@ debug: objects libs dlls apps tools
 pin_exec: $(OBJDIR)pin_exec.so
 
 $(OBJDIR)%.o: $(COMMON_LIB_PATH)/%.cc
-	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -DPIN_COMPILE
+	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -MMD -DPIN_COMPILE
 
 $(OBJDIR)%.o: %.cc
-	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -DPIN_COMPILE
+	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -MMD -DPIN_COMPILE
 
 commonlibs: $(COMMON_LIB_OBJFILES)
 
@@ -110,3 +110,8 @@ $(OBJDIR)pin_exec$(OBJ_SUFFIX):pin_exec.cpp
 	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -MD -DPIN_COMPILE
 
 -include $(OBJDIR)pin_exec.d
+# Header-dependency tracking for the tool sources and the shared pin_lib objects, so that changing
+# a shared header (e.g. ctype_pin_inst.h) rebuilds every dependent object instead of leaving a stale
+# one with a mismatched struct layout (which corrupts the pin<->scarab socket protocol).
+-include $(SOURCE_OBJFILES:.o=.d)
+-include $(COMMON_LIB_OBJFILES:.o=.d)

--- a/src/pin/pin_trace/makefile.rules
+++ b/src/pin/pin_trace/makefile.rules
@@ -85,10 +85,10 @@ READ_TRACE_CXXFLAGS =  -std=c++14 -O3 -I$(SCARAB_DIR)
 gen_trace: $(OBJDIR)gen_trace.so
 
 $(OBJDIR)%.o: $(COMMON_LIB_PATH)/%.cc
-	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -DPIN_COMPILE
+	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -MMD -DPIN_COMPILE
 
 $(OBJDIR)%.o: %.cc
-	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -DPIN_COMPILE
+	$(CXX) $(TOOL_CXXFLAGS) $(COMP_OBJ)$@ $< -MMD -DPIN_COMPILE
 
 $(OBJDIR)isa.o: $(SCARAB_DIR)/isa/isa.c
 	$(CC) $(READ_TRACE_CFLAGS) $(COMP_OBJ)$@ $<
@@ -112,3 +112,7 @@ $(OBJDIR)read_trace: read_trace.cc dir $(SCARAB_OBJFILES)
 
 -include $(OBJDIR)gen_trace.d
 -include $(OBJDIR)read_trace.d
+# Track headers for the tool sources and shared pin_lib objects so a shared-header change
+# (e.g. ctype_pin_inst.h) rebuilds every dependent object instead of leaving a stale one.
+-include $(SOURCE_OBJFILES:.o=.d)
+-include $(COMMON_LIB_OBJFILES:.o=.d)


### PR DESCRIPTION
Only pin_exec.cpp/gen_trace.cc were compiled with dependency tracking; the generic %.o rules for the tool sources and shared pin_lib objects (decoder.cc, pin_scarab_common_lib.cc, ...) had none. So changing a shared header (e.g. ctype_pin_inst.h) left those objects stale, producing a pin tool whose struct layout diverged from scarab's and corrupting the pin<->scarab socket protocol (manifested as spurious op_type/assert failures on the next run).

Add -MMD to the %.o rules and -include the generated .d files for both pin_exec and pin_trace.