### PR TITLE
[BUGFIX] ISSUE_WIDTH param adjust

### DIFF
--- a/src/PARAMS.golden_cove
+++ b/src/PARAMS.golden_cove
@@ -92,9 +92,11 @@
 --decode_cycles                 5
 
 ### Instruction Decode Queue
+--dispatch_width                6
 --idq_size                      144
 
 ### Map Stage
+--rename_width                  6
 --map_cycles                    5
 
 # register renaming table
@@ -103,10 +105,6 @@
 --reg_table_vector_physical_size    332
 
 ### Issue Stage
-
-# Max number of instructions to be renamed, and issued per cycle.
---issue_width                   6
-
 --rs_fill_width                 0
 # rs_sizes ~205 in total, and they are split into three different reservation stations (RS1, RS2, RS3) where each has 97, 70, 38 entries respectively
 # original architecture

--- a/src/PARAMS.sunny_cove
+++ b/src/PARAMS.sunny_cove
@@ -82,9 +82,11 @@
 --decode_cycles                 5
 
 ### Instruction Decode Queue
+--dispatch_width                6
 --idq_size                      140
 
 ### Map Stage
+--rename_width                  6
 --map_cycles                    5
 
 # register renaming table
@@ -93,10 +95,6 @@
 --reg_table_vector_physical_size    224
 
 ### Issue Stage
-
-# Max number of instructions to be renamed, and issued per cycle.
---issue_width                   6
-
 --rs_fill_width                 0
 # rs_sizes 160 in total, but they are split between four different reservation stations https://www.anandtech.com/show/14514/examining-intels-ice-lake-microarchitecture-and-sunny-cove/3
 # Remove Port 4 and Port 9 (one RS) from the original architecture and allow ST to Port 3 and Port 7

--- a/src/core.param.def
+++ b/src/core.param.def
@@ -123,7 +123,6 @@ DEF_PARAM(topdown_fu_exec_few, TOPDOWN_FU_EXEC_FEW, uns, uns, 0, )
 
 /********NODE TABLE
  * PARAMETERS********************************************************/
-DEF_PARAM(issue_width, ISSUE_WIDTH, uns, uns, 4, )
 DEF_PARAM(rs_fill_width, RS_FILL_WIDTH, uns, uns, 8, )
 DEF_PARAM(node_table_size, NODE_TABLE_SIZE, uns, uns, 256, )
 DEF_PARAM(node_ret_width, NODE_RET_WIDTH, uns, uns, 4, )
@@ -139,10 +138,12 @@ DEF_PARAM(decode_width, DECODE_WIDTH, uns, uns, 4, )
 
 /********INSTRUCTION DECODE QUEUE
  * PARAMETERS********************************************************/
+DEF_PARAM(dispatch_width, DISPATCH_WIDTH, uns, uns, 4, )
 DEF_PARAM(idq_size, IDQ_SIZE, uns, uns, 140, )
 
 /********MAP REGISTER FILE
  * PARAMETERS********************************************************/
+DEF_PARAM(rename_width, RENAME_WIDTH, uns, uns, 4, )
 DEF_PARAM(reg_renaming_scheme, REG_RENAMING_SCHEME, uns, uns, 0, )
 DEF_PARAM(reg_table_integer_physical_size, REG_TABLE_INTEGER_PHYSICAL_SIZE, uns, uns, 256, )
 DEF_PARAM(reg_table_vector_physical_size, REG_TABLE_VECTOR_PHYSICAL_SIZE, uns, uns, 256, )

--- a/src/idq_stage.cc
+++ b/src/idq_stage.cc
@@ -83,7 +83,6 @@ struct IDQ_Stage {
   /* the IDQ outpur stage data */
   Stage_Data idq_sd = {};
   // Backing storage for `idq_sd.ops` (avoids explicit per-init malloc).
-  // Note: `ISSUE_WIDTH` is a parameter and may not be a compile-time constant.
   std::vector<Op*> idq_ops;
 
   // Backing storage for `idq_sd.name` (avoids per-init `strdup` leaks and
@@ -113,8 +112,8 @@ void IDQ_Stage::init(uns8 _proc_id, const char* name) {
   snprintf(tmp_name, MAX_STR_LENGTH, "%s %d", name, 0);
   idq_stage_name = tmp_name;
   idq_sd.name = idq_stage_name.data();
-  idq_sd.max_op_count = ISSUE_WIDTH;
-  idq_ops.assign(ISSUE_WIDTH, NULL);
+  idq_sd.max_op_count = DISPATCH_WIDTH;
+  idq_ops.assign(DISPATCH_WIDTH, NULL);
   idq_sd.ops = idq_ops.data();
   idq_sd.op_count = 0;
 

--- a/src/map_stage.c
+++ b/src/map_stage.c
@@ -57,7 +57,7 @@
 /**************************************************************************************/
 /* Macros */
 #define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_MAP_STAGE, ##args)
-#define STAGE_MAX_OP_COUNT ISSUE_WIDTH
+#define STAGE_MAX_OP_COUNT RENAME_WIDTH
 #define STAGE_MAX_DEPTH MAP_CYCLES
 
 /**************************************************************************************/

--- a/src/node_stage.c
+++ b/src/node_stage.c
@@ -70,7 +70,7 @@
 #define DEBUG(proc_id, args...) _DEBUG(proc_id, DEBUG_NODE_STAGE, ##args)
 #define PRINT_RETIRED_UOP(proc_id, args...) _DEBUG_LEAN(proc_id, DEBUG_RETIRED_UOPS, ##args)
 
-#define DEBUG_NODE_WIDTH ISSUE_WIDTH
+#define DEBUG_NODE_WIDTH DISPATCH_WIDTH
 /**************************************************************************************/
 /* Global Variables */
 

--- a/src/power/power_scarab_config.cc
+++ b/src/power/power_scarab_config.cc
@@ -563,8 +563,7 @@ void power_print_core_params(std::ofstream& out, uint32_t core_id) {
   uns pipeline_depth = DECODE_CYCLES + MAP_CYCLES + 1 + 1 + 1 + 1;  // icache, node, exec, retire
 
   /* Scarab: theoretical peak ops per cycle */
-  uns32 peak_ops_per_cycle =
-      std::min(std::min(NUM_FUS, ISSUE_WIDTH), std::min(RS_FILL_WIDTH == 0 ? MAX_INT : RS_FILL_WIDTH, NODE_RET_WIDTH));
+  uns32 peak_ops_per_cycle = std::min(NUM_FUS, std::min(RS_FILL_WIDTH == 0 ? MAX_INT : RS_FILL_WIDTH, NODE_RET_WIDTH));
   DEBUG(core_id, "peak_ops_per_cycle: %d\n", peak_ops_per_cycle);
 
   double ops_per_cycle =

--- a/src/topdown.c
+++ b/src/topdown.c
@@ -88,7 +88,7 @@ void topdown_bp_recovery(uns proc_id, Op* op) {
 }
 
 void topdown_idq_update(uns proc_id, int count_available, int count_issued, int count_issued_on_path) {
-  INC_STAT_EVENT(proc_id, TOPDOWN_TOTAL_SLOTS, ISSUE_WIDTH);
+  INC_STAT_EVENT(proc_id, TOPDOWN_TOTAL_SLOTS, DISPATCH_WIDTH);
   INC_STAT_EVENT(proc_id, TOPDOWN_ISSUED_SLOTS, count_issued);
   INC_STAT_EVENT(proc_id, TOPDOWN_RETIRED_SLOTS, count_issued_on_path);
 
@@ -96,7 +96,7 @@ void topdown_idq_update(uns proc_id, int count_available, int count_issued, int 
   if (recovery_cycle != 0) {
     ASSERT(proc_id, recovery_cycle > 0);
     idq_stage_set_recovery_cycle(recovery_cycle - 1);
-    INC_STAT_EVENT(proc_id, TOPDOWN_RECOVERY_BUBBLES_SLOTS, ISSUE_WIDTH - count_available);
+    INC_STAT_EVENT(proc_id, TOPDOWN_RECOVERY_BUBBLES_SLOTS, DISPATCH_WIDTH - count_available);
     return;
   }
 
@@ -111,7 +111,7 @@ void topdown_idq_update(uns proc_id, int count_available, int count_issued, int 
     return;
   }
 
-  INC_STAT_EVENT(proc_id, TOPDOWN_FETCH_BUBBLES_SLOTS, ISSUE_WIDTH - count_available);
+  INC_STAT_EVENT(proc_id, TOPDOWN_FETCH_BUBBLES_SLOTS, DISPATCH_WIDTH - count_available);
   if (count_available == 0)
     STAT_EVENT(proc_id, TOPDOWN_FETCH_BUBBLES_GT_MIW_CYCLES);
 }


### PR DESCRIPTION
Scarab defines ISSUE_WIDTH as the width of renaming and dispatching, which is incorrect.
This patch aims at fixing this definition, by adding the params of DISPATH_WIDTH and RENAME_WIDTH. ISSUE_WIDTH can be used by NUM_FUS.