### PR TITLE
2.4–4.1% Runtime reduction using Intrusive List

### DIFF
--- a/src/issue_queue.cc
+++ b/src/issue_queue.cc
@@ -53,7 +53,6 @@ extern "C" {
 
 #include <algorithm>
 #include <deque>
-#include <list>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -114,6 +113,10 @@ struct IssueQueueEntry {
 
   uns32 bound_fu_id = MAX_UNS;
   ISSUE_QUEUE_ENTRY_STATE state = ISSUE_QUEUE_ENTRY_STATE_EMPTY;
+
+  IssueQueueEntry* ready_prev = nullptr;
+  IssueQueueEntry* ready_next = nullptr;
+  bool in_ready_list = false;
 
   explicit IssueQueueEntry(uns16 queue_id, uns16 entry_id) : queue_id(queue_id), entry_id(entry_id) {}
   void clear();
@@ -273,7 +276,7 @@ class SelectLogic {
   std::unique_ptr<BindPolicy> bind_policy;
 
   std::vector<size_t> picker_order;  // picker traversal order generated each cycle
-  std::list<IssueQueueEntry*> ready_list;
+  IssueQueueEntry* ready_head = nullptr;
 
   // bitmask of ready but not yet issued op types in this cycle
   uns64 ready_not_issued_op_types = 0;
@@ -296,15 +299,44 @@ class SelectLogic {
 
   void bind(IssueQueueEntry* entry) { bind_policy->bind(connected_fu_pickers, entry); }
   void unbind(IssueQueueEntry* entry) { bind_policy->unbind(entry); }
-  void request(IssueQueueEntry* entry) { ready_list.push_front(entry); }
-  void release(IssueQueueEntry* entry) { ready_list.remove(entry); }
+  void request(IssueQueueEntry* entry);
+  void release(IssueQueueEntry* entry);
 
-  bool has_ready_ops() const { return !ready_list.empty(); }
+  bool has_ready_ops() const { return ready_head != nullptr; }
   uns64 get_ready_not_issued_op_types() const { return ready_not_issued_op_types; }
 
   void collect_entry_op_ready_stats(IssueQueueEntry* entry);
   void collect_entry_op_ready_not_issued_stats(IssueQueueEntry* entry);
 };
+
+void SelectLogic::request(IssueQueueEntry* entry) {
+  ASSERT(proc_id, entry->queue_id == queue_id && !entry->in_ready_list);
+
+  entry->ready_prev = nullptr;
+  entry->ready_next = ready_head;
+  if (ready_head != nullptr)
+    ready_head->ready_prev = entry;
+  ready_head = entry;
+  entry->in_ready_list = true;
+}
+
+void SelectLogic::release(IssueQueueEntry* entry) {
+  if (!entry->in_ready_list)
+    return;
+
+  ASSERT(proc_id, entry->queue_id == queue_id);
+  if (entry->ready_prev != nullptr)
+    entry->ready_prev->ready_next = entry->ready_next;
+  else
+    ready_head = entry->ready_next;
+
+  if (entry->ready_next != nullptr)
+    entry->ready_next->ready_prev = entry->ready_prev;
+
+  entry->ready_prev = nullptr;
+  entry->ready_next = nullptr;
+  entry->in_ready_list = false;
+}
 
 /*
  * Serial selection is described in "Quantifying the complexity of superscalar processors", 1996.
@@ -320,7 +352,7 @@ void SelectLogic::bid() {
   ready_not_issued_op_types = 0;
   ready_not_issued_op_types_per_fu.assign(connected_fu_pickers.size(), 0);
 
-  for (IssueQueueEntry* entry : ready_list) {
+  for (IssueQueueEntry* entry = ready_head; entry != nullptr; entry = entry->ready_next) {
     // check if the op is ready (it may become not ready due to memory blocking or waiting for forwarding)
     if (entry->state != ISSUE_QUEUE_ENTRY_STATE_READY || !issue_queue_check_op_ready(entry->op)) {
       continue;


### PR DESCRIPTION
**Synopsis:** The main costs were the separate allocation and deallocation of std::list nodes and the O(n) search performed by std::list::remove(). The intrusive-list implementation embeds the links directly in IssueQueueEntry, eliminating the separate list-node allocation and making removal O(1).

1. entry points to an IssueQueueEntry.
2. The list stores that pointer as a value inside a separate list node.
3. remove(entry) searches O(n) for a list node whose stored pointer equals entry.
4. It rewrites that node’s neighbors.
5. It destroys and deallocates the list node.
6. The IssueQueueEntry remains alive.

New intrusive version:
1. entry still points to the same IssueQueueEntry.
2. That object contains its own ready_prev and ready_next.
3. Removal directly rewrites the neighboring entries’ pointers in O(1).
4. It clears its own links and marks itself absent.
5. No separate list node is destroyed or deallocated.
7. The existing IssueQueueEntry storage can be reused later.

Each configuration was run five times per workload.
--------------------------------------------------------------------------------------------------------
perlbench baseline:  172.809 176.254 179.626 179.016 174.971
perlbench intrusive: 171.727 172.098 167.382 174.223 173.108

mcf baseline:        189.910 189.889 188.556 188.726 186.323
mcf intrusive:       183.181 184.945 181.768 182.377 183.901

lbm baseline:        153.271 156.487 156.928 157.641 156.354
lbm intrusive:       148.014 150.310 151.904 151.468 149.615

- 570 of 570 simulator-output comparisons matched excluding SIM_HOST_WALL_SECONDS
- IPC is identical.
- Simulated instruction counts are identical.
- Simulated cycle counts are identical.
- Cache, branch predictor, memory, prefetcher, power, and Ramulator statistics are identical.
- All 15 PARAMS.out comparisons matched
-------------------------------------------------------------------------------------------------------
Notes:
<img width="2196" height="568" alt="image" src="https://github.com/user-attachments/assets/f0bf4307-e448-4cdb-a73c-55ed2ad9b410" />
<img width="1246" height="419" alt="image" src="https://github.com/user-attachments/assets/28cf9908-788a-4693-ac47-a382b0a43050" />
<img width="1199" height="321" alt="image" src="https://github.com/user-attachments/assets/56ed0308-e432-4597-927f-29b8b110beda" />
<img width="1334" height="284" alt="image" src="https://github.com/user-attachments/assets/3d1a1cfe-069c-491a-b59c-a89fc2f5a86e" />
<img width="921" height="848" alt="image" src="https://github.com/user-attachments/assets/4578e5d4-d53a-49c6-b5ad-7bdbf05cb080" />
<img width="961" height="546" alt="image" src="https://github.com/user-attachments/assets/935ab78d-163f-4fcf-8430-2cd714d0eeff" />
<img width="1364" height="374" alt="image" src="https://github.com/user-attachments/assets/730b404e-7cd3-4213-bbe5-01bd2f477b4e" />
<img width="674" height="811" alt="image" src="https://github.com/user-attachments/assets/61a5aa06-1662-4951-9374-9f306dfafd33" />
<img width="1974" height="518" alt="image" src="https://github.com/user-attachments/assets/99270213-1df9-40bf-a493-c355dc048f73" />
<img width="2251" height="959" alt="image" src="https://github.com/user-attachments/assets/d0bbf388-e16a-40d6-a897-2c935ed5648c" />
<img width="1801" height="1134" alt="image" src="https://github.com/user-attachments/assets/cccc0fbc-624d-4d2d-9917-c8275dbad720" />

**Future work:** I’ve made two optimizations to the structure of a data container, so now I’m thinking about making bigger changes that could improve speed. I plan to learn some new tools to help me find similar structures. For example, if I have 15 files that could all use small-size optimized vectors to boost speed or memory performance, I could create one shared structure and use it across those files. I think this is the next step in my learning.

I'll also be fixing my bug fix, but I wanted to work on some heaptrack stuff. 

